### PR TITLE
Don't return Link header if it's blank

### DIFF
--- a/lib/api-pagination.rb
+++ b/lib/api-pagination.rb
@@ -22,7 +22,7 @@ module ApiPagination
         %(<#{url}?#{new_params.to_param}>; rel="#{k}")
       end
 
-      headers['Link'] = links.join(', ')
+      headers['Link'] = links.join(', ') unless links.empty?
     end
 end
 

--- a/spec/controllers/numbers_controller_spec.rb
+++ b/spec/controllers/numbers_controller_spec.rb
@@ -34,7 +34,7 @@ describe NumbersController, :type => :controller do
     context 'without enough items to give more than one page' do
       it 'should not paginate' do
         get :index, count: 20
-        response.headers['Link'].should be_blank
+        response.headers.keys.should_not include("Link")
       end
     end
 


### PR DESCRIPTION
I think it's better not to include the Link header at all if it's empty. I think that's standard practice. GitHub's API, for example, does not return the Link header if there's no pagination information. I added `unless links.empty?` to prevent the header from being returned if it's empty, and modified the test as well to check that the list of headers does not include "Link" in that case.
