### PR TITLE
default variable name derived from controller

### DIFF
--- a/lib/api-pagination.rb
+++ b/lib/api-pagination.rb
@@ -2,7 +2,8 @@ require 'api-pagination/version'
 
 module ApiPagination
   protected
-    def paginate(scope)
+    def paginate(scope=nil)
+      scope ||= self.class.to_s.sub("Controller", "").underscore.split('/').last.pluralize
       scope = instance_variable_get(:"@#{scope}")
       url   = request.original_url.sub(/\?.*$/, '')
       pages = {}


### PR DESCRIPTION
This is a very small change to make the pagination scope default sensibly. The stemming steps are pinched from cancan. 

For a consistent API it means I can just put

`after_filter :paginate, :only => [:index]`

in the base ApiController and then forget about it.

I was tempted to rewrite the interface as `paginate :pages`, but what you have is lovely and simple and I didn't want to spoil that.
