### PR TITLE
Fix typo in will_paginate support

### DIFF
--- a/lib/api-pagination/hooks.rb
+++ b/lib/api-pagination/hooks.rb
@@ -20,7 +20,7 @@ module ApiPagination
       end
 
       begin; require 'will_paginate'; rescue LoadError; end
-      if defined?(WillPaginate::CollectionMethod)
+      if defined?(WillPaginate::CollectionMethods)
         WillPaginate::CollectionMethods.module_eval do
           def first_page?() !previous_page end
           def last_page?() !next_page end


### PR DESCRIPTION
will_paginate doesn't provide `WillPaginate::CollectionMethod`, but it does provide `WillPaginate::CollectionMethods`.

It looks like this was a regression introduced in the code reorganization of 2c5bb35d.
