### PR TITLE
Add support for Sequel ORM

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,8 @@ gemspec
 gem 'kaminari', require: false
 gem 'will_paginate', require: false
 
+gem 'sqlite3', require: false
+gem 'sequel', require: false
+
 gem 'rake', require: false
 gem 'coveralls', require: false

--- a/api-pagination.gemspec
+++ b/api-pagination.gemspec
@@ -20,4 +20,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'grape'
   s.add_development_dependency 'railties', '>= 3.0.0'
   s.add_development_dependency 'actionpack', '>= 3.0.0'
+  s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'sequel', '>= 4.9.0'
 end

--- a/lib/api-pagination.rb
+++ b/lib/api-pagination.rb
@@ -14,7 +14,11 @@ module ApiPagination
         collection = Kaminari.paginate_array(collection) if collection.is_a?(Array)
         collection.page(options[:page]).per(options[:per_page])
       when :will_paginate
-        collection.paginate(:page => options[:page], :per_page => options[:per_page])
+        if defined?(Sequel::Dataset) && collection.kind_of?(Sequel::Dataset)
+          collection.paginate(options[:page], options[:per_page])
+        else
+          collection.paginate(:page => options[:page], :per_page => options[:per_page])
+        end
       end
     end
 

--- a/spec/sequel_spec.rb
+++ b/spec/sequel_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+if ApiPagination.paginator == :will_paginate
+  require 'sqlite3'
+  require 'sequel'
+  require 'will_paginate/sequel'
+
+  DB = Sequel.sqlite
+  DB.extension :pagination
+  DB.create_table :people do
+    primary_key :id
+    String :name
+  end
+
+  describe 'Using will_paginate with Sequel' do
+    let(:people) do
+      DB[:people]
+    end
+
+    before(:each) do
+      people.insert(name: 'John')
+      people.insert(name: 'Mary')
+    end
+
+    it 'returns a Sequel::Dataset' do
+      collection = ApiPagination.paginate(people)
+      expect(collection.kind_of?(Sequel::Dataset)).to be_true
+    end
+  end
+end
+


### PR DESCRIPTION
The sequel orm has it's own `#pagination` method. `will_paginate` doesn't override or wrap this method, it instead just uses the built in sequel pagination method. However, sequel's `#paginate` has a different method signature, instead of a hash or named parameters, it looks like this:

``` ruby
   def paginate(page_no, page_size, record_count=nil)
     # ...
   end
```

I couldn't think of a cleaner way to support Sequel, so what it does is check to see if `collections` inherits from `Sequel::Dataset` and if it does, it'll call `#paginate` with Sequel's method signature. If you have a better way to implement this, let me know and I'll do my best to modify this PR.
