### PR TITLE
Fix will_paginate specs

### DIFF
--- a/lib/api-pagination.rb
+++ b/lib/api-pagination.rb
@@ -1,4 +1,3 @@
-require 'api-pagination/hooks'
 require 'api-pagination/version'
 
 module ApiPagination
@@ -19,6 +18,8 @@ module ApiPagination
         else
           collection.paginate(:page => options[:page], :per_page => options[:per_page])
         end
+      else
+        fail StandardError, "Unknown paginator: #{ApiPagination.paginator}"
       end
     end
 
@@ -44,3 +45,5 @@ module ApiPagination
     end
   end
 end
+
+require 'api-pagination/hooks'


### PR DESCRIPTION
Fixes the will_paginate specs, and adds a little bit of logic to make the library complain if it can't resolve the pagination library.  Specifically:
1. Moved the ENV library directly into the lib code itself
2. Added code to raise an error on an unknown paginator
3. Added a warning if the library is loaded in an environment where both kaminari and will_paginate are loaded.
