### PR TITLE
Added support to API proxies.

### DIFF
--- a/lib/grape/pagination.rb
+++ b/lib/grape/pagination.rb
@@ -8,10 +8,16 @@ module Grape
             :per_page => (params[:per_page] || settings[:per_page])
           }
           collection = ApiPagination.paginate(collection, options)
+          links      = (header['Link'] || "").split(',').map(&:strip)
+          pages      = ApiPagination.pages_from(collection)
 
-          links = (header['Link'] || "").split(',').map(&:strip)
-          url   = request.url.sub(/\?.*$/, '')
-          pages = ApiPagination.pages_from(collection)
+          url = request.url.sub(/\?.*$/, '')
+          url = URI.parse(url).request_uri if settings[:relative_uri]
+
+          if settings[:exclude_base_path]
+            base_path_regexp = Regexp.new("^" + settings[:exclude_base_path])
+            url = url.sub(base_path_regexp, "")
+          end
 
           pages.each do |k, v|
             old_params = Rack::Utils.parse_query(request.query_string)
@@ -28,6 +34,25 @@ module Grape
 
       base.class_eval do
         def self.paginate(options = {})
+          # URIs can also be relative, useful when using API proxies.
+          #
+          # From RFC 5988 (Web Linking):
+          # "If the URI-Reference is relative, parsers MUST resolve it
+          # as per [RFC3986], Section 5.""
+          set :relative_uri, (options[:relative_uri] || false)
+
+          # When using API proxies, you probably want to hide base path
+          # from returned links since proxies point to your API base path
+          # directly making its own resources not have such base path.
+          #
+          # E.g.
+          # If your application has the following API resource:
+          #   mywebsite.example.com/api/v1/resource.json
+          # And that's accessible though the following API proxy resource:
+          #   myproxy.example.com/v1/resource.json
+          # You don't want links to return '/api/v1/...', but '/v1/...'.
+          set :exclude_base_path, (options[:exclude_base_path] || false)
+
           set :per_page, (options[:per_page] || 25)
           params do
             optional :page,     :type => Integer, :default => 1,

--- a/spec/grape_spec.rb
+++ b/spec/grape_spec.rb
@@ -53,3 +53,19 @@ describe NumbersAPI do
     end
   end
 end
+
+describe NumbersProxiedAPI do
+  describe 'GET #index' do
+    let(:links) { last_response.headers['Link'].split(', ') }
+    let(:total) { last_response.headers['Total'].to_i }
+
+    context 'with existing Link headers' do
+      before { get "/api/numbers", :count => 30 }
+
+      it 'should contain relative pagination Links without base path' do
+        expect(links).to include('</numbers?count=30&page=2>; rel="next"')
+        expect(links).to include('</numbers?count=30&page=3>; rel="last"')
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'support/numbers_controller'
 require 'support/numbers_api'
+require 'support/numbers_proxied_api'
 require 'api-pagination'
 
 if ENV['PAGINATOR']
@@ -31,6 +32,8 @@ RSpec.configure do |config|
   config.order = 'random'
 
   def app
-    NumbersAPI
+    # Allows us to test different API apps.
+    # e.g. NumbersApi, NumbersProxiedApi...
+    described_class
   end
 end

--- a/spec/support/numbers_proxied_api.rb
+++ b/spec/support/numbers_proxied_api.rb
@@ -1,0 +1,22 @@
+require 'grape'
+require 'api-pagination'
+
+class NumbersProxiedAPI < Grape::API
+  format :json
+
+  # This namespace is here simulate that the API is nested in a directory.
+  # When using an API proxy, this base path vanishes since the proxy host
+  # is the new base. That's why we have 'exclude_base_path'.
+  namespace :api do
+    desc 'Return some paginated set of numbers'
+    paginate :per_page          => 10,
+             :exclude_base_path => "/api",
+             :relative_uri      => true
+    params do
+      requires :count, :type => Integer
+    end
+    get :numbers do
+      paginate (1..params[:count]).to_a
+    end
+  end
+end


### PR DESCRIPTION
API Proxies are services that work in the middle between your clients and your API server.
They are useful for handling some API-exclusive logic so that you don't have to such as usage statistics, authentication, etc.
Some examples of API Proxies are: Apigee, 3scale and Mashery.

Current version of api-pagination generates links based on `request.url` but when we use a proxy that generate direct links to the API server which we don't want to expose (and which you probably made it unaccessible to outsiders anyway).

My approach to solve this problem was pretty simple: provide the option to generate relative links.
Relative links are allowed according to the Web Linking [RFC5988](http://tools.ietf.org/html/rfc5988#section-5.1).
So there's now an option `:relative_uri` which should be set to true if user so desires.

Another issue that I've stumbled upon was the base path.
Many APIs probably set a different domain such as `api.example.com` which makes all paths the same when using a proxy (unless you set something else in the proxy).
Other APIs though are nested in the main domain (e.g. `example.com/api`), maybe to be able to use SSL without new or expensive certificates.
That said, we should be able to hide such "/api" base path because from the client perspective (accessing through the proxy) that base path doesn't exist. More details in code comments.
I made that possible through the option `exclude_base_path`.

I've also added proper tests and they all pass.
This solution is already successfully being used in a production app of mine.

Hope this helps everyone.
