### PR TITLE
Adding support for a max_per_page parameter.

### DIFF
--- a/lib/api-pagination.rb
+++ b/lib/api-pagination.rb
@@ -11,15 +11,21 @@ module ApiPagination
 
       case ApiPagination.paginator
       when :kaminari
-        if Kaminari.config.max_per_page && options[:per_page] > Kaminari.config.max_per_page
-          options[:per_page] = Kaminari.config.max_per_page
+        max_per_page = (options[:max_per_page] || Kaminari.config.max_per_page).to_i
+        if options[:max_per_page] && options[:per_page] > max_per_page
+          options[:per_page] = max_per_page
         elsif options[:per_page] <= 0
           options[:per_page] = Kaminari.config.default_per_page
         end
         collection = Kaminari.paginate_array(collection) if collection.is_a?(Array)
         collection.page(options[:page]).per(options[:per_page])
       when :will_paginate
-        options[:per_page] = WillPaginate.per_page if options[:per_page] <= 0
+        max_per_page = options[:max_per_page].to_i
+        if options[:max_per_page] && options[:per_page] > max_per_page
+          options[:per_page] = max_per_page
+        elsif options[:per_page] <= 0
+          options[:per_page] = WillPaginate.per_page
+        end
 
         if defined?(Sequel::Dataset) && collection.kind_of?(Sequel::Dataset)
           collection.paginate(options[:page], options[:per_page])

--- a/lib/grape/pagination.rb
+++ b/lib/grape/pagination.rb
@@ -5,7 +5,8 @@ module Grape
         def paginate(collection)
           options = {
             :page     => params[:page],
-            :per_page => (params[:per_page] || settings[:per_page])
+            :per_page => (params[:per_page] || settings[:per_page]),
+            :max_per_page => settings[:max_per_page]
           }
           collection = ApiPagination.paginate(collection, options)
 
@@ -13,8 +14,10 @@ module Grape
           url   = request.url.sub(/\?.*$/, '')
           pages = ApiPagination.pages_from(collection)
 
+          old_params = Rack::Utils.parse_query(request.query_string)
+          old_params['per_page'] = options[:per_page] if old_params['per_page']
+
           pages.each do |k, v|
-            old_params = Rack::Utils.parse_query(request.query_string)
             new_params = old_params.merge('page' => v)
             links << %(<#{url}?#{new_params.to_param}>; rel="#{k}")
           end
@@ -29,11 +32,12 @@ module Grape
       base.class_eval do
         def self.paginate(options = {})
           set :per_page, (options[:per_page] || 25)
+          set :max_per_page, options[:max_per_page]
           params do
-            optional :page,     :type => Integer, :default => 1,
-                                :desc => 'Page of results to fetch.'
-            optional :per_page, :type => Integer,
-                                :desc => 'Number of results to return per page.'
+            optional :page,         :type => Integer, :default => 1,
+                                    :desc => 'Page of results to fetch.'
+            optional :per_page,     :type => Integer,
+                                    :desc => 'Number of results to return per page.'
           end
         end
       end

--- a/lib/rails/pagination.rb
+++ b/lib/rails/pagination.rb
@@ -25,14 +25,17 @@ module Rails
 
     def _paginate_collection(collection, options={})
       options = {
-        :page     => params[:page],
-        :per_page => (options.delete(:per_page) || params[:per_page])
+        :page         => params[:page],
+        :per_page     => (options.delete(:per_page) || params[:per_page]),
+        :max_per_page => options[:max_per_page]
       }
       collection = ApiPagination.paginate(collection, options)
 
       links = (headers['Link'] || "").split(',').map(&:strip)
       url   = request.original_url.sub(/\?.*$/, '')
       pages = ApiPagination.pages_from(collection)
+
+      request.query_parameters[:per_page] = options[:per_page] if request.query_parameters[:per_page]
 
       pages.each do |k, v|
         new_params = request.query_parameters.merge(:page => v)

--- a/spec/grape_spec.rb
+++ b/spec/grape_spec.rb
@@ -26,6 +26,18 @@ describe NumbersAPI do
       end
     end
 
+    context 'with per_page larger than max_per_page' do
+      before { get :numbers, :count => 100, :per_page => 50 }
+
+      it 'should only return max_per_page items' do
+        expect(last_response.body).to eq('[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20]')
+      end
+
+      it 'should correct the per_page parameter in links' do
+        expect(links).to include('<http://example.org/numbers?count=100&page=5&per_page=20>; rel="last"')
+      end
+    end
+
     context 'with existing Link headers' do
       before { get :numbers, :count => 30, :with_headers => true }
 

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -28,6 +28,18 @@ describe NumbersController, :type => :controller do
       end
     end
 
+    context 'with per_page larger than max_per_page' do
+      before { get :index, :count => 100, :per_page => 50 }
+
+      it 'should only return max_per_page items' do
+        expect(response.body).to eq('[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20]')
+      end
+
+      it 'should correct the per_page parameter in links' do
+        expect(links).to include('<http://example.org/numbers?count=100&page=5&per_page=20>; rel="last"')
+      end
+    end
+
     context 'with existing Link headers' do
       before { get :index, :count => 30, :with_headers => true }
 

--- a/spec/support/numbers_api.rb
+++ b/spec/support/numbers_api.rb
@@ -5,7 +5,7 @@ class NumbersAPI < Grape::API
   format :json
 
   desc 'Return some paginated set of numbers'
-  paginate :per_page => 10
+  paginate :per_page => 10, :max_per_page => 20
   params do
     requires :count, :type => Integer
     optional :with_headers, :default => false, :type => Boolean

--- a/spec/support/numbers_controller.rb
+++ b/spec/support/numbers_controller.rb
@@ -66,7 +66,7 @@ class NumbersController < ActionController::Base
       headers['Link'] = %(<#{numbers_url}?#{query.to_param}>; rel="without")
     end
 
-    paginate :json => (1..total).to_a, :per_page => 10
+    paginate :json => (1..total).to_a, :per_page => params[:per_page] || 10, :max_per_page => 20
   end
 
   def index_with_custom_render


### PR DESCRIPTION
Sorry for the pull request out of nowhere, but I love the gem but I need a max_per_page parameter so that I can override the Kaminari max_per_page inside of my api controllers. Hopefully I'm not duplicating work anyone else is doing.