### PR TITLE
support for Grape 0.10 with refactored settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .bundle
 .config
 .yardoc
+.ruby-version
 Gemfile.lock
 InstalledFiles
 _yardoc

--- a/api-pagination.gemspec
+++ b/api-pagination.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_development_dependency 'rspec', '~> 3.0'
-  s.add_development_dependency 'grape'
+  s.add_development_dependency 'grape', '>= 0.10.0'
   s.add_development_dependency 'railties', '>= 3.0.0'
   s.add_development_dependency 'actionpack', '>= 3.0.0'
   s.add_development_dependency 'sequel', '>= 4.9.0'

--- a/lib/grape/pagination.rb
+++ b/lib/grape/pagination.rb
@@ -5,7 +5,7 @@ module Grape
         def paginate(collection)
           options = {
             :page     => params[:page],
-            :per_page => (params[:per_page] || settings[:per_page])
+            :per_page => (params[:per_page] || route_setting(:per_page))
           }
           collection = ApiPagination.paginate(collection, options)
 
@@ -28,7 +28,7 @@ module Grape
 
       base.class_eval do
         def self.paginate(options = {})
-          set :per_page, (options[:per_page] || 25)
+          route_setting :per_page, (options[:per_page] || 25)
           params do
             optional :page,     :type => Integer, :default => 1,
                                 :desc => 'Page of results to fetch.'


### PR DESCRIPTION
This pull request enables support for Grape 0.10 since they refactored the way settings are set and retrieved.  Also added Appraisals gem to test both versions locally and on travis-CI.  

If you can find a prettier way of dealing with this please comment or update.

Can run specs against Grape 0.10 and 0.9 with: 

bundle exec appraisal rspec spec

  