### PR TITLE
Allowing to configure custom headers for Total and Per-Page

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@ This follows the proposed [RFC-5988](http://tools.ietf.org/html/rfc5988) standar
 In your `Gemfile`:
 
 ```ruby
-# Requires Rails (Rails-API is also supported) or Grape.
+# Requires Rails (Rails-API is also supported), or Grape
+# v0.10.0 or later. If you're on an earlier version of
+# Grape, use api-pagination ~> 3.1
 gem 'rails', '>= 3.0.0'
 gem 'rails-api'
-gem 'grape'
+gem 'grape', '>= 0.10.0'
 
 # Then choose your preferred paginator from the following:
 gem 'kaminari'

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Link: <http://localhost:3000/movies?page=1>; rel="first",
   <http://localhost:3000/movies?page=6>; rel="next",
   <http://localhost:3000/movies?page=4>; rel="prev"
 Total: 4321
+Per-Page: 10
 # ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ class MoviesController < ApplicationController
 end
 ```
 
-This will pull your collection from the `json` or `xml` option, paginate it for you using `params[:page]` and `params[:per_page]`, render Link headers, and call `ActionController::Base#render` with whatever you passed to `paginate`. This should work well with [ActiveModel::Serializers](https://github.com/rails-api/active_model-serializers). However, if you need more control over what is done with your paginated collection, you can pass the collection directly to `paginate` instead of in a way that mimics `render`:
+This will pull your collection from the `json` or `xml` option, paginate it for you using `params[:page]` and `params[:per_page]`, render Link headers, and call `ActionController::Base#render` with whatever you passed to `paginate`. This should work well with [ActiveModel::Serializers](https://github.com/rails-api/active_model-serializers). However, if you need more control over what is done with your paginated collection, you can pass the collection directly to `paginate` to receive a paginated collection and have your headers set. Then, you can pass that paginated collection to a serializer or do whatever you want with it:
 
 ```ruby
 class MoviesController < ApplicationController
@@ -69,13 +69,11 @@ class MoviesController < ApplicationController
 end
 ```
 
-This will avoid implicitly calling `render` at the end. Instead, `paginate` will simply set up the headers and return your collection so you can do whatever you want with it.
-
-Note that the collection sent to `paginate` _must_ respond to your paginator's methods. For Kaminari, `Kaminari.paginate_array` will be called for you behind-the-scenes. For WillPaginate, you're out of luck unless you call `require 'will_paginate/array'` somewhere. Because this pollutes `Array`, it won't be done for you automatically.
+Note that the collection sent to `paginate` _must_ respond to your paginator's methods. This is typically fine unless you're dealing with a stock Array. For Kaminari, `Kaminari.paginate_array` will be called for you behind-the-scenes. For WillPaginate, you're out of luck unless you call `require 'will_paginate/array'` somewhere. Because this pollutes `Array`, it won't be done for you automatically.
 
 ## Grape
 
-With Grape, `paginate` is used to declare that your endpoint takes a `:page` and `:per_page` param. Inside your API endpoint, it simply takes your collection:
+With Grape, `paginate` is used to declare that your endpoint takes a `:page` and `:per_page` param. You can also directly specify a `:max_per_page` that users aren't allowed to go over. Then, inside your API endpoint, it simply takes your collection:
 
 ```ruby
 class MoviesAPI < Grape::API
@@ -93,7 +91,8 @@ class MoviesAPI < Grape::API
     desc "Return one movie's cast, paginated"
     # Override how many Actors get returned. If unspecified,
     # params[:per_page] (which defaults to 25) will be used.
-    paginate per_page: 10
+    # There is no default for `max_per_page`.
+    paginate per_page: 10, max_per_page: 200
     get :cast do
       paginate Movie.find(params[:id]).actors
     end

--- a/lib/api-pagination/version.rb
+++ b/lib/api-pagination/version.rb
@@ -1,7 +1,7 @@
 module ApiPagination
   class Version
-    MAJOR = 3
-    MINOR = 1
+    MAJOR = 4
+    MINOR = 0
     PATCH = 0
 
     def self.to_s

--- a/lib/grape/pagination.rb
+++ b/lib/grape/pagination.rb
@@ -19,8 +19,9 @@ module Grape
             links << %(<#{url}?#{new_params.to_param}>; rel="#{k}")
           end
 
-          header 'Link', links.join(', ') unless links.empty?
-          header 'Total', ApiPagination.total_from(collection)
+          header 'Link',     links.join(', ') unless links.empty?
+          header 'Total',    ApiPagination.total_from(collection)
+          header 'Per-Page', options[:per_page]
 
           return collection
         end

--- a/lib/grape/pagination.rb
+++ b/lib/grape/pagination.rb
@@ -3,9 +3,10 @@ module Grape
     def self.included(base)
       Grape::Endpoint.class_eval do
         def paginate(collection)
+          per_page = params[:per_page] || route_setting(:per_page)
           options = {
             :page     => params[:page],
-            :per_page => (params[:per_page] || route_setting(:per_page))
+            :per_page => [per_page, route_setting(:max_per_page)].compact.min
           }
           collection = ApiPagination.paginate(collection, options)
 
@@ -30,6 +31,7 @@ module Grape
       base.class_eval do
         def self.paginate(options = {})
           route_setting :per_page, (options[:per_page] || 25)
+          route_setting :max_per_page, options[:max_per_page]
           params do
             optional :page,     :type => Integer, :default => 1,
                                 :desc => 'Page of results to fetch.'

--- a/lib/rails/pagination.rb
+++ b/lib/rails/pagination.rb
@@ -39,11 +39,11 @@ module Rails
         links << %(<#{url}?#{new_params.to_param}>; rel="#{k}")
       end
 
-      headers['Link']  = links.join(', ') unless links.empty?
-      headers['Total'] = ApiPagination.total_from(collection)
+      headers['Link']     = links.join(', ') unless links.empty?
+      headers['Total']    = ApiPagination.total_from(collection)
+      headers['Per-Page'] = options[:per_page]
 
       return collection
     end
   end
 end
-

--- a/spec/grape_spec.rb
+++ b/spec/grape_spec.rb
@@ -8,9 +8,10 @@ describe NumbersAPI do
   describe 'GET #index' do
     let(:links) { last_response.headers['Link'].split(', ') }
     let(:total) { last_response.headers['Total'].to_i }
+    let(:per_page) { last_response.headers['Per-Page'].to_i }
 
     context 'without enough items to give more than one page' do
-      before { get :numbers, :count => 10 }
+      before { get '/numbers', :count => 10 }
 
       it 'should not paginate' do
         expect(last_response.headers.keys).not_to include('Link')
@@ -20,6 +21,10 @@ describe NumbersAPI do
         expect(total).to eq(10)
       end
 
+      it 'should give a Per-Page header' do
+        expect(per_page).to eq(10)
+      end
+
       it 'should list all numbers in the response body' do
         body = '[1,2,3,4,5,6,7,8,9,10]'
         expect(last_response.body).to eq(body)
@@ -27,26 +32,26 @@ describe NumbersAPI do
     end
 
     context 'with existing Link headers' do
-      before { get :numbers, :count => 30, :with_headers => true }
+      before { get '/numbers', :count => 30, :with_headers => true }
 
       it_behaves_like 'an endpoint with existing Link headers'
     end
 
     context 'with enough items to paginate' do
       context 'when on the first page' do
-        before { get :numbers, :count => 100 }
+        before { get '/numbers', :count => 100 }
 
         it_behaves_like 'an endpoint with a first page'
       end
 
       context 'when on the last page' do
-        before { get :numbers, :count => 100, :page => 10 }
+        before { get '/numbers', :count => 100, :page => 10 }
 
         it_behaves_like 'an endpoint with a last page'
       end
 
       context 'when somewhere comfortably in the middle' do
-        before { get :numbers, :count => 100, :page => 2 }
+        before { get '/numbers', :count => 100, :page => 2 }
 
         it_behaves_like 'an endpoint with a middle page'
       end

--- a/spec/grape_spec.rb
+++ b/spec/grape_spec.rb
@@ -55,6 +55,16 @@ describe NumbersAPI do
 
         it_behaves_like 'an endpoint with a middle page'
       end
+
+      context 'with a max_per_page setting' do
+        before { get '/numbers', :count => 100, :per_page => 30 }
+
+        it 'should not go above the max_per_page_limit' do
+          body = '[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25]'
+
+          expect(last_response.body).to eq(body)
+        end
+      end
     end
   end
 end

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -10,6 +10,7 @@ describe NumbersController, :type => :controller do
   describe 'GET #index' do
     let(:links) { response.headers['Link'].split(', ') }
     let(:total) { response.headers['Total'].to_i }
+    let(:per_page) { response.headers['Per-Page'].to_i }
 
     context 'without enough items to give more than one page' do
       before { get :index, :count => 10 }
@@ -20,6 +21,10 @@ describe NumbersController, :type => :controller do
 
       it 'should give a Total header' do
         expect(total).to eq(10)
+      end
+
+      it 'should give a Per-Page header' do
+        expect(per_page).to eq(10)
       end
 
       it 'should list all numbers in the response body' do
@@ -65,8 +70,3 @@ describe NumbersController, :type => :controller do
     end
   end
 end
-
-
-
-
-

--- a/spec/support/numbers_api.rb
+++ b/spec/support/numbers_api.rb
@@ -5,7 +5,7 @@ class NumbersAPI < Grape::API
   format :json
 
   desc 'Return some paginated set of numbers'
-  paginate :per_page => 10
+  paginate :per_page => 10, :max_per_page => 25 
   params do
     requires :count, :type => Integer
     optional :with_headers, :default => false, :type => Boolean


### PR DESCRIPTION
- not always we want to have the Total and Per-Page headers with that
  name, we may want to have a custom one like: X-Total-Count or
  X-Per-Page.
- if nothing is configured it defaults to Total and Per-Page as the gem
  already did.