### PR TITLE
Allowing to configure custom headers for Total and Per-Page

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ class MoviesAPI < Grape::API
 end
 ```
 
+## Headers
+
 Then `curl --include` to see your header-based pagination in action:
 
 ```bash
@@ -111,6 +113,27 @@ Link: <http://localhost:3000/movies?page=1>; rel="first",
   <http://localhost:3000/movies?page=4>; rel="prev"
 Total: 4321
 Per-Page: 10
+# ...
+```
+
+If you want, you can customize the name of `Total` and `Per-Page` headers.  
+All you need to do is to set the `total_header` or `per_page_header` on `ApiPagination`.  
+If nothing is setted it defaults to `Total` and `Per-Page`.
+
+```ruby
+ApiPagination.total_header = 'X-Total-Count'
+ApiPagination.per_page_header = 'X-Per-Page'
+```
+
+```bash
+$ curl --include 'https://localhost:3000/movies?page=5'
+HTTP/1.1 200 OK
+Link: <http://localhost:3000/movies?page=1>; rel="first",
+  <http://localhost:3000/movies?page=173>; rel="last",
+  <http://localhost:3000/movies?page=6>; rel="next",
+  <http://localhost:3000/movies?page=4>; rel="prev"
+X-Total-Count: 4321
+X-Per-Page: 10
 # ...
 ```
 

--- a/lib/api-pagination.rb
+++ b/lib/api-pagination.rb
@@ -3,6 +3,7 @@ require 'api-pagination/version'
 module ApiPagination
   class << self
     attr_reader :paginator
+    attr_writer :total_header, :per_page_header
 
     def paginate(collection, options = {})
       options[:page]     = options[:page].to_i
@@ -50,6 +51,14 @@ module ApiPagination
         when :kaminari      then collection.total_count.to_s
         when :will_paginate then collection.total_entries.to_s
       end
+    end
+
+    def total_header
+      @total_header ||= 'Total'
+    end
+
+    def per_page_header
+      @per_page_header ||= 'Per-Page'
     end
   end
 end

--- a/lib/grape/pagination.rb
+++ b/lib/grape/pagination.rb
@@ -20,9 +20,12 @@ module Grape
             links << %(<#{url}?#{new_params.to_param}>; rel="#{k}")
           end
 
-          header 'Link',     links.join(', ') unless links.empty?
-          header 'Total',    ApiPagination.total_from(collection)
-          header 'Per-Page', options[:per_page]
+          total_header    = ApiPagination.total_header
+          per_page_header = ApiPagination.per_page_header
+
+          header 'Link',          links.join(', ') unless links.empty?
+          header total_header,    ApiPagination.total_from(collection)
+          header per_page_header, options[:per_page].to_s
 
           return collection
         end

--- a/lib/rails/pagination.rb
+++ b/lib/rails/pagination.rb
@@ -39,9 +39,12 @@ module Rails
         links << %(<#{url}?#{new_params.to_param}>; rel="#{k}")
       end
 
-      headers['Link']     = links.join(', ') unless links.empty?
-      headers['Total']    = ApiPagination.total_from(collection)
-      headers['Per-Page'] = options[:per_page].to_s
+      total_header    = ApiPagination.total_header
+      per_page_header = ApiPagination.per_page_header
+
+      headers['Link']          = links.join(', ') unless links.empty?
+      headers[total_header]    = ApiPagination.total_from(collection)
+      headers[per_page_header] = options[:per_page].to_s
 
       return collection
     end

--- a/spec/grape_spec.rb
+++ b/spec/grape_spec.rb
@@ -66,5 +66,38 @@ describe NumbersAPI do
         end
       end
     end
+
+    context 'with custom response headers' do
+      before do
+        ApiPagination.total_header    = 'X-Total-Count'
+        ApiPagination.per_page_header = 'X-Per-Page'
+
+        get '/numbers', count: 10
+      end
+
+      after do
+        ApiPagination.total_header    = nil
+        ApiPagination.per_page_header = nil
+      end
+
+      let(:total) { last_response.header['X-Total-Count'].to_i }
+      let(:per_page) { last_response.header['X-Per-Page'].to_i }
+
+      it 'should give a X-Total-Count header' do
+        headers_keys = last_response.headers.keys
+
+        expect(headers_keys).not_to include('Total')
+        expect(headers_keys).to include('X-Total-Count')
+        expect(total).to eq(10)
+      end
+
+      it 'should give a X-Per-Page header' do
+        headers_keys = last_response.headers.keys
+
+        expect(headers_keys).not_to include('Per-Page')
+        expect(headers_keys).to include('X-Per-Page')
+        expect(per_page).to eq(10)
+      end
+    end
   end
 end

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -68,5 +68,38 @@ describe NumbersController, :type => :controller do
         expect(response.body).to eq(json)
       end
     end
+
+    context 'with custom response headers' do
+      before do
+        ApiPagination.total_header    = 'X-Total-Count'
+        ApiPagination.per_page_header = 'X-Per-Page'
+
+        get :index, count: 10
+      end
+
+      after do
+        ApiPagination.total_header    = nil
+        ApiPagination.per_page_header = nil
+      end
+
+      let(:total) { response.header['X-Total-Count'].to_i }
+      let(:per_page) { response.header['X-Per-Page'].to_i }
+
+      it 'should give a X-Total-Count header' do
+        headers_keys = response.headers.keys
+
+        expect(headers_keys).not_to include('Total')
+        expect(headers_keys).to include('X-Total-Count')
+        expect(total).to eq(10)
+      end
+
+      it 'should give a X-Per-Page header' do
+        headers_keys = response.headers.keys
+
+        expect(headers_keys).not_to include('Per-Page')
+        expect(headers_keys).to include('X-Per-Page')
+        expect(per_page).to eq(10)
+      end
+    end
   end
 end


### PR DESCRIPTION
- not always we want to have the Total and Per-Page headers with that
  name, we may want to have a custom one like: X-Total-Count or
  X-Per-Page.
- if nothing is configured it defaults to Total and Per-Page as the gem
  already did.

Merged with the other pull requests that caused conflicts.