### PR TITLE
[WIP] Make paginator definition explicit

### DIFF
--- a/lib/api-pagination.rb
+++ b/lib/api-pagination.rb
@@ -1,9 +1,15 @@
 require 'api-pagination/version'
+require 'api-pagination/hooks'
 
 module ApiPagination
   class << self
-    attr_reader :paginator
-    attr_writer :total_header, :per_page_header
+    attr_accessor :paginator
+    attr_writer   :total_header, :per_page_header
+
+    def config
+      yield(self) if block_given?
+      ApiPagination::Hooks.init!
+    end
 
     def paginate(collection, options = {})
       options[:page]     = options[:page].to_i
@@ -62,5 +68,3 @@ module ApiPagination
     end
   end
 end
-
-require 'api-pagination/hooks'

--- a/lib/api-pagination/hooks.rb
+++ b/lib/api-pagination/hooks.rb
@@ -41,12 +41,11 @@ module ApiPagination
   EOC
       end
 
-
       case ApiPagination.paginator
       when :will_paginate
-        initialize_kaminari! and return
-      when :kaminari
         initialize_will_paginate! and return
+      when :kaminari
+        initialize_kaminari! and return
       when nil
         if _cannot_infer_paginator?
           STDERR.puts <<-EOC

--- a/lib/api-pagination/hooks.rb
+++ b/lib/api-pagination/hooks.rb
@@ -19,43 +19,45 @@ module ApiPagination
         Grape::API.send(:include, Grape::Pagination)
       end
 
-      # Kaminari and will_paginate conflict with each other, so we should check
-      # to see if either is already active before attempting to load them.
-      if defined?(Kaminari) && defined?(WillPaginate::CollectionMethods)
-        STDERR.puts <<-EOC
-Warning: api-pagination relies on either Kaminari or WillPaginate, but these
-gems conflict.  Please ensure only one of them is active at any given time.
-
-EOC
-        return
-      elsif defined?(Kaminari)
-        initialize_kaminari! and return
-      elsif defined?(WillPaginate::CollectionMethods)
-        initialize_will_paginate! and return
-      end
-      # If neither is loaded, we can safely attempt these requires.
-      unless ApiPagination.paginator == :will_paginate
-        begin
-          require 'kaminari'
-          initialize_kaminari! and return
-        rescue LoadError
-        end
+      # Make sure kaminari or will paginate are defined
+      begin
+        require 'kaminari'
+      rescue LoadError
       end
 
       begin
         require 'will_paginate'
-        initialize_will_paginate! and return
       rescue LoadError
       end
 
-      STDERR.puts <<-EOC
-Warning: api-pagination relies on either Kaminari or WillPaginate. Please
-install either dependency by adding one of the following to your Gemfile:
+      if _no_paginator_found?
+        STDERR.puts <<-EOC
+  Warning: api-pagination relies on either Kaminari or WillPaginate. Please
+  install either dependency by adding one of the following to your Gemfile:
 
-gem 'kaminari'
-gem 'will_paginate'
+  gem 'kaminari'
+  gem 'will_paginate'
 
-EOC
+  EOC
+      end
+
+
+      case ApiPagination.paginator
+      when :will_paginate
+        initialize_kaminari! and return
+      when :kaminari
+        initialize_will_paginate! and return
+      when nil
+        if _cannot_infer_paginator?
+          STDERR.puts <<-EOC
+  Warning: api-pagination relies on either Kaminari or WillPaginate, but these
+  gems conflict. Please set ApiPagination.paginator in an initializer.
+
+  EOC
+          return
+        end
+      end
+
     end
 
     def self.initialize_kaminari!
@@ -71,7 +73,14 @@ EOC
 
       ApiPagination.instance_variable_set(:@paginator, :will_paginate)
     end
+
+    def self._cannot_infer_paginator?
+      defined?(Kaminari) &&
+        defined?(WillPaginate::CollectionMethods) && ApiPagination.paginator.nil?
+    end
+
+    def self._no_paginator_found?
+      !defined?(Kaminari) && !defined?(WillPaginate::CollectionMethods)
+    end
   end
 end
-
-ApiPagination::Hooks.init!


### PR DESCRIPTION
There are cases when both will_paginate and kaminari will be in your dependencies, even though you're only using one of them. In our case we're using will_paginate and activeadmin (which internally uses kaminari for pagination).

I've modified the way ApiPagination initializes to allow explicit paginator definition. It works like this:

initializers/api_pagination.rb
```
ApiPagination.config do |options|
  options.paginator = :will_paginate
end
```

This way you can have both kaminari and will_paginate defined and still be able you use this gem for api pagination.

You do loose the ability to just include the gem in the gemfile and be done with it (now you also need to define an initializer).

It should be possible to have both, what do you think about this workflow?