### PR TITLE
Get page from options

### DIFF
--- a/lib/rails/pagination.rb
+++ b/lib/rails/pagination.rb
@@ -25,7 +25,7 @@ module Rails
 
     def _paginate_collection(collection, options={})
       options = {
-        :page     => params[:page],
+        :page     => (options.delete(:page) || params[:page]),
         :per_page => (options.delete(:per_page) || params[:per_page])
       }
       collection = ApiPagination.paginate(collection, options)


### PR DESCRIPTION
Hello. Excuse me for my bad english, because I use a google-translator. This commit was applied to a pagination could indicate the number of pages in the options, not just in the params of get.