### PR TITLE
Add support new response headers: Current-Page & Total-Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ ApiPagination.configure do |config|
 
   # By default, this is set to 'Per-Page'
   config.per_page_header = 'X-Per-Page'
+
+  # By default, this is set to 'Current-Page'
+  config.current_page_header = 'X-Current-Page'
+
+  # By default, this is set to 'Total-Pages'
+  config.total_pages_header = 'X-Total-Pages'
 end
 ```
 
@@ -130,6 +136,8 @@ Link: <http://localhost:3000/movies?page=1>; rel="first",
   <http://localhost:3000/movies?page=4>; rel="prev"
 Total: 4321
 Per-Page: 10
+Current-Page: 5
+Total-Pages: 433
 # ...
 ```
 

--- a/lib/api-pagination/configuration.rb
+++ b/lib/api-pagination/configuration.rb
@@ -1,16 +1,16 @@
 module ApiPagination
   class Configuration
-    attr_accessor :total_header
-
-    attr_accessor :per_page_header
+    attr_accessor :total_header, :per_page_header, :current_page_header, :total_pages_header
 
     def configure(&block)
       yield self
     end
 
     def initialize
-      @total_header    = 'Total'
-      @per_page_header = 'Per-Page'
+      @total_header         = 'Total'
+      @per_page_header      = 'Per-Page'
+      @current_page_header  = 'Current-Page'
+      @total_pages_header   = 'Total-Pages'
     end
 
     def paginator

--- a/lib/grape/pagination.rb
+++ b/lib/grape/pagination.rb
@@ -20,12 +20,17 @@ module Grape
             links << %(<#{url}?#{new_params.to_param}>; rel="#{k}")
           end
 
-          total_header    = ApiPagination.config.total_header
-          per_page_header = ApiPagination.config.per_page_header
+          total_header        = ApiPagination.config.total_header
+          per_page_header     = ApiPagination.config.per_page_header
+          current_page_header = ApiPagination.config.current_page_header
+          total_pages_header  = ApiPagination.config.total_pages_header
+          total_collection    = ApiPagination.total_from(collection)
 
-          header 'Link',          links.join(', ') unless links.empty?
-          header total_header,    ApiPagination.total_from(collection)
-          header per_page_header, options[:per_page].to_s
+          header 'Link',              links.join(', ') unless links.empty?
+          header total_header,        total_collection
+          header per_page_header,     options[:per_page].to_s
+          header current_page_header, options[:page].to_s
+          header total_pages_header,  (total_collection.to_f / options[:per_page].to_f).ceil.to_s
 
           return collection
         end

--- a/lib/rails/pagination.rb
+++ b/lib/rails/pagination.rb
@@ -39,12 +39,17 @@ module Rails
         links << %(<#{url}?#{new_params.to_param}>; rel="#{k}")
       end
 
-      total_header    = ApiPagination.config.total_header
-      per_page_header = ApiPagination.config.per_page_header
+      total_header        = ApiPagination.config.total_header
+      per_page_header     = ApiPagination.config.per_page_header
+      current_page_header = ApiPagination.config.current_page_header
+      total_pages_header  = ApiPagination.config.total_pages_header
+      total_collection    = ApiPagination.total_from(collection)
 
-      headers['Link']          = links.join(', ') unless links.empty?
-      headers[total_header]    = ApiPagination.total_from(collection)
-      headers[per_page_header] = options[:per_page].to_s
+      headers['Link']               = links.join(', ') unless links.empty?
+      headers[total_header]         = total_collection
+      headers[per_page_header]      = options[:per_page].to_s
+      headers[current_page_header]  = options[:page].to_s
+      headers[total_pages_header]   = (total_collection.to_f / options[:per_page].to_f).ceil.to_s
 
       return collection
     end

--- a/spec/grape_spec.rb
+++ b/spec/grape_spec.rb
@@ -6,9 +6,11 @@ require 'support/shared_examples/last_page'
 
 describe NumbersAPI do
   describe 'GET #index' do
-    let(:links) { last_response.headers['Link'].split(', ') }
-    let(:total) { last_response.headers['Total'].to_i }
-    let(:per_page) { last_response.headers['Per-Page'].to_i }
+    let(:links)         { last_response.headers['Link'].split(', ') }
+    let(:total)         { last_response.headers['Total'].to_i }
+    let(:per_page)      { last_response.headers['Per-Page'].to_i }
+    let(:current_page)  { last_response.headers['Current-Page'].to_i }
+    let(:total_pages)   { last_response.headers['Total-Pages'].to_i }
 
     context 'without enough items to give more than one page' do
       before { get '/numbers', :count => 10 }
@@ -23,6 +25,14 @@ describe NumbersAPI do
 
       it 'should give a Per-Page header' do
         expect(per_page).to eq(10)
+      end
+
+      it 'should give a Current-Page header' do
+        expect(current_page).to eq(1)
+      end
+
+      it 'should give a Total-Pages header' do
+        expect(total_pages).to eq(1)
       end
 
       it 'should list all numbers in the response body' do
@@ -69,19 +79,25 @@ describe NumbersAPI do
 
     context 'with custom response headers' do
       before do
-        ApiPagination.config.total_header    = 'X-Total-Count'
-        ApiPagination.config.per_page_header = 'X-Per-Page'
+        ApiPagination.config.total_header         = 'X-Total-Count'
+        ApiPagination.config.per_page_header      = 'X-Per-Page'
+        ApiPagination.config.current_page_header  = 'X-Current-Page'
+        ApiPagination.config.total_pages_header   = 'X-Total-Pages'
 
         get '/numbers', count: 10
       end
 
       after do
-        ApiPagination.config.total_header    = 'Total'
-        ApiPagination.config.per_page_header = 'Per-Page'
+        ApiPagination.config.total_header         = 'Total'
+        ApiPagination.config.per_page_header      = 'Per-Page'
+        ApiPagination.config.current_page_header  = 'Current-Page'
+        ApiPagination.config.total_pages_header   = 'Total-Pages'
       end
 
-      let(:total) { last_response.header['X-Total-Count'].to_i }
-      let(:per_page) { last_response.header['X-Per-Page'].to_i }
+      let(:total)         { last_response.header['X-Total-Count'].to_i }
+      let(:per_page)      { last_response.header['X-Per-Page'].to_i }
+      let(:current_page)  { last_response.header['X-Current-Page'].to_i }
+      let(:total_pages)   { last_response.header['X-Total-Pages'].to_i }
 
       it 'should give a X-Total-Count header' do
         headers_keys = last_response.headers.keys
@@ -97,6 +113,22 @@ describe NumbersAPI do
         expect(headers_keys).not_to include('Per-Page')
         expect(headers_keys).to include('X-Per-Page')
         expect(per_page).to eq(10)
+      end
+
+      it 'should give a X-Current-Page header' do
+        headers_keys = last_response.headers.keys
+
+        expect(headers_keys).not_to include('Current-Page')
+        expect(headers_keys).to include('X-Current-Page')
+        expect(current_page).to eq(1)
+      end
+
+      it 'should give a X-Total-Pages header' do
+        headers_keys = last_response.headers.keys
+
+        expect(headers_keys).not_to include('Total-Pages')
+        expect(headers_keys).to include('X-Total-Pages')
+        expect(total_pages).to eq(1)
       end
     end
   end

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -8,9 +8,11 @@ describe NumbersController, :type => :controller do
   before { request.host = 'example.org' }
 
   describe 'GET #index' do
-    let(:links) { response.headers['Link'].split(', ') }
-    let(:total) { response.headers['Total'].to_i }
-    let(:per_page) { response.headers['Per-Page'].to_i }
+    let(:links)         { response.headers['Link'].split(', ') }
+    let(:total)         { response.headers['Total'].to_i }
+    let(:per_page)      { response.headers['Per-Page'].to_i }
+    let(:current_page)  { response.headers['Current-Page'].to_i }
+    let(:total_pages)   { response.headers['Total-Pages'].to_i }
 
     context 'without enough items to give more than one page' do
       before { get :index, :count => 10 }
@@ -25,6 +27,14 @@ describe NumbersController, :type => :controller do
 
       it 'should give a Per-Page header' do
         expect(per_page).to eq(10)
+      end
+
+      it 'should give a Current-Page header' do
+        expect(current_page).to eq(1)
+      end
+
+      it 'should give a Total-Pages header' do
+        expect(total_pages).to eq(1)
       end
 
       it 'should list all numbers in the response body' do
@@ -71,19 +81,25 @@ describe NumbersController, :type => :controller do
 
     context 'with custom response headers' do
       before do
-        ApiPagination.config.total_header    = 'X-Total-Count'
-        ApiPagination.config.per_page_header = 'X-Per-Page'
+        ApiPagination.config.total_header         = 'X-Total-Count'
+        ApiPagination.config.per_page_header      = 'X-Per-Page'
+        ApiPagination.config.current_page_header  = 'X-Current-Page'
+        ApiPagination.config.total_pages_header   = 'X-Total-Pages'
 
         get :index, count: 10
       end
 
       after do
-        ApiPagination.config.total_header    = 'Total'
-        ApiPagination.config.per_page_header = 'Per-Page'
+        ApiPagination.config.total_header         = 'Total'
+        ApiPagination.config.per_page_header      = 'Per-Page'
+        ApiPagination.config.current_page_header  = 'Current-Page'
+        ApiPagination.config.total_pages_header   = 'Total-Pages'
       end
 
-      let(:total) { response.header['X-Total-Count'].to_i }
-      let(:per_page) { response.header['X-Per-Page'].to_i }
+      let(:total)         { response.header['X-Total-Count'].to_i }
+      let(:per_page)      { response.header['X-Per-Page'].to_i }
+      let(:current_page)  { response.header['X-Current-Page'].to_i }
+      let(:total_pages)   { response.header['X-Total-Pages'].to_i }
 
       it 'should give a X-Total-Count header' do
         headers_keys = response.headers.keys
@@ -99,6 +115,22 @@ describe NumbersController, :type => :controller do
         expect(headers_keys).not_to include('Per-Page')
         expect(headers_keys).to include('X-Per-Page')
         expect(per_page).to eq(10)
+      end
+
+      it 'should give a X-Current-Page header' do
+        headers_keys = response.headers.keys
+
+        expect(headers_keys).not_to include('Current-Page')
+        expect(headers_keys).to include('X-Current-Page')
+        expect(current_page).to eq(1)
+      end
+
+      it 'should give a X-Total-Pages header' do
+        headers_keys = response.headers.keys
+
+        expect(headers_keys).not_to include('Total-Pages')
+        expect(headers_keys).to include('X-Total-Pages')
+        expect(total_pages).to eq(1)
       end
     end
   end

--- a/spec/support/shared_examples/existing_headers.rb
+++ b/spec/support/shared_examples/existing_headers.rb
@@ -11,4 +11,12 @@ shared_examples 'an endpoint with existing Link headers' do
   it 'should give a Total header' do
     expect(total).to eq(30)
   end
+
+  it 'should give a Current-Page header' do
+    expect(current_page).to eq(1)
+  end
+
+  it 'should give a Total-Pages header' do
+    expect(total_pages).to eq(3)
+  end
 end

--- a/spec/support/shared_examples/first_page.rb
+++ b/spec/support/shared_examples/first_page.rb
@@ -19,6 +19,14 @@ shared_examples 'an endpoint with a first page' do
     expect(total).to eq(100)
   end
 
+  it 'should give a Current-Page header' do
+    expect(current_page).to eq(1)
+  end
+
+  it 'should give a Total-Pages header' do
+    expect(total_pages).to eq(10)
+  end
+
   it 'should list the first page of numbers in the response body' do
     body = '[1,2,3,4,5,6,7,8,9,10]'
     if defined?(response)

--- a/spec/support/shared_examples/last_page.rb
+++ b/spec/support/shared_examples/last_page.rb
@@ -19,6 +19,14 @@ shared_examples 'an endpoint with a last page' do
     expect(total).to eq(100)
   end
 
+  it 'should give a Current-Page header' do
+    expect(current_page).to eq(10)
+  end
+
+  it 'should give a Total-Pages header' do
+    expect(total_pages).to eq(10)
+  end
+
   it 'should list the last page of numbers in the response body' do
     body = '[91,92,93,94,95,96,97,98,99,100]'
 

--- a/spec/support/shared_examples/middle_page.rb
+++ b/spec/support/shared_examples/middle_page.rb
@@ -10,6 +10,14 @@ shared_examples 'an endpoint with a middle page' do
     expect(total).to eq(100)
   end
 
+  it 'should give a Current-Page header' do
+    expect(current_page).to eq(2)
+  end
+
+  it 'should give a Total-Pages header' do
+    expect(total_pages).to eq(10)
+  end
+
   it 'should list a middle page of numbers in the response body' do
     body = '[11,12,13,14,15,16,17,18,19,20]'
 


### PR DESCRIPTION
Hi. I added support new response headers: Current-Page & Total-Pages.

Example:
```bash
$ curl --include 'https://localhost:3000/movies?page=5'
HTTP/1.1 200 OK
Link: <http://localhost:3000/movies?page=1>; rel="first",
  <http://localhost:3000/movies?page=173>; rel="last",
  <http://localhost:3000/movies?page=6>; rel="next",
  <http://localhost:3000/movies?page=4>; rel="prev"
Total: 4321
Per-Page: 10
Current-Page: 5
Total-Pages: 433
# ...
```