### PR TITLE
Allow to pass `page` option to `paginate` method

### DIFF
--- a/lib/rails/pagination.rb
+++ b/lib/rails/pagination.rb
@@ -25,7 +25,7 @@ module Rails
 
     def _paginate_collection(collection, options={})
       options = {
-        :page     => params[:page],
+        :page     => (options.delete(:page)     || params[:page]),
         :per_page => (options.delete(:per_page) || params[:per_page])
       }
       collection = ApiPagination.paginate(collection, options)

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -101,5 +101,19 @@ describe NumbersController, :type => :controller do
         expect(per_page).to eq(10)
       end
     end
+
+    context 'with passed page option' do
+      before { get :index_with_alt_page, :count => 100 }
+
+      it 'should return the correct page' do
+        body = '[11,12,13,14,15,16,17,18,19,20]'
+
+        if defined?(response)
+          expect(response.body).to eq(body)
+        else
+          expect(last_response.body).to eq(body)
+        end
+      end
+    end
   end
 end

--- a/spec/support/numbers_controller.rb
+++ b/spec/support/numbers_controller.rb
@@ -41,6 +41,7 @@ end
 Rails.application.routes.draw do
   resources :numbers, :only => [:index] do
     get :index_with_custom_render, on: :collection
+    get :index_with_alt_page,      on: :collection
   end
 end
 
@@ -75,5 +76,11 @@ class NumbersController < ActionController::Base
     numbers = paginate numbers, :per_page => 10
 
     render json: NumbersSerializer.new(numbers)
+  end
+
+  def index_with_alt_page
+    total = params.fetch(:count).to_i
+
+    paginate :json => (1..total).to_a, :per_page => 10, page: 2
   end
 end


### PR DESCRIPTION
```
def cast
  actors = Movie.find(params[:id]).actors
  paginate json: actors, per_page: 10, page: 2
end
```

I'm working in an application where the current `page` is not specified via `params[:page]`, thus passing the `page` to `paginate` just like the `per_page` option would be quite nice. Without this option I have to manually set the current page to `params[:page]`

A notable downside however is that if someone would be using an alternative parameter like eg. `params[:current]` the generated links in the header will be incorrect:

```
<http://example.org/numbers/index_with_alt_page?count=100&current=2&page=1>; rel="first"
<http://example.org/numbers/index_with_alt_page?count=100&current=2&page=1>; rel="prev"
<http://example.org/numbers/index_with_alt_page?count=100&current=2&page=10>; rel="last"
<http://example.org/numbers/index_with_alt_page?count=100&current=2&page=3>; rel="next"
```