### PR TITLE
Return array query parameters same as received

### DIFF
--- a/lib/grape/pagination.rb
+++ b/lib/grape/pagination.rb
@@ -15,7 +15,7 @@ module Grape
           pages = ApiPagination.pages_from(collection)
 
           pages.each do |k, v|
-            old_params = Rack::Utils.parse_query(request.query_string)
+            old_params = Rack::Utils.parse_nested_query(request.query_string)
             new_params = old_params.merge('page' => v)
             links << %(<#{url}?#{new_params.to_param}>; rel="#{k}")
           end

--- a/spec/grape_spec.rb
+++ b/spec/grape_spec.rb
@@ -106,8 +106,8 @@ describe NumbersAPI do
       end
 
       it 'returns links with with same received parameters' do
-        expect(links).to include('<http://example.org/numbers?count=100&page=10&state%5B%5D=new&state%5B%5D=active>; rel="last"')
-        expect(links).to include('<http://example.org/numbers?count=100&page=2&state%5B%5D=new&state%5B%5D=active>; rel="next"')
+        expect(links).to include('<http://example.org/numbers?count=100&page=10&parity%5B%5D=odd&parity%5B%5D=even>; rel="last"')
+        expect(links).to include('<http://example.org/numbers?count=100&page=2&parity%5B%5D=odd&parity%5B%5D=even>; rel="next"')
       end
     end
   end

--- a/spec/grape_spec.rb
+++ b/spec/grape_spec.rb
@@ -99,5 +99,16 @@ describe NumbersAPI do
         expect(per_page).to eq(10)
       end
     end
+
+    context 'with query string including array parameter' do
+      before do
+        get '/numbers', { count: 100, parity: ['odd', 'even']}
+      end
+
+      it 'returns links with with same received parameters' do
+        expect(links).to include('<http://example.org/numbers?count=100&page=10&state%5B%5D=new&state%5B%5D=active>; rel="last"')
+        expect(links).to include('<http://example.org/numbers?count=100&page=2&state%5B%5D=new&state%5B%5D=active>; rel="next"')
+      end
+    end
   end
 end


### PR DESCRIPTION
Hi there,

we have api with resource which can be in multiple states. We want to filter by that state.
When we try to filter by multiple states at once we get back invalid pagination links
request url:
http://api.com/api/v1/resource?page=1&state%5B%5D=new&state%5B%5D=active
decoded query string = "?page=1&state[]=active&state[]=new"
returned link:
<http://api.com/api/v1/resource?page=30&**state%5B%5D%5B%5D=new&state%5B%5D%5B%5D=active**>; rel="last"
decoded query string = "?page=1&**state[][]=active&state[][]=new**"

The problem is in parsing old parameters as you can see in commit. For parsing array arguments with brackets `Rack::Utils.parse_nested_query` must be used.

Note:
Since we are in rails land mostly i assume we want to use array query parameters with square brackets. It is what `#to_query` from `ActiveSupport` used here produces anyway. But since this change changes output of generated links it could theoretically break existing apis :P but anyway i think it should be fixed