### PR TITLE
Keep former behaviour for Kaminari.paginate_array

### DIFF
--- a/lib/api-pagination.rb
+++ b/lib/api-pagination.rb
@@ -10,7 +10,7 @@ module ApiPagination
 
       case ApiPagination.config.paginator
       when :kaminari
-        paginate_with_kaminari(collection, options)
+        paginate_with_kaminari(collection, options, options[:paginate_array_options] || {})
       when :will_paginate
         paginate_with_will_paginate(collection, options)
       else
@@ -56,14 +56,14 @@ module ApiPagination
 
     private
 
-    def paginate_with_kaminari(collection, options)
+    def paginate_with_kaminari(collection, options, paginate_array_options = {})
       if Kaminari.config.max_per_page && options[:per_page] > Kaminari.config.max_per_page
         options[:per_page] = Kaminari.config.max_per_page
       elsif options[:per_page] <= 0
         options[:per_page] = Kaminari.config.default_per_page
       end
 
-      collection = Kaminari.paginate_array(collection) if collection.is_a?(Array)
+      collection = Kaminari.paginate_array(collection, paginate_array_options) if collection.is_a?(Array)
       collection.page(options[:page]).per(options[:per_page])
     end
 

--- a/spec/api-pagination_spec.rb
+++ b/spec/api-pagination_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe ApiPagination do
+  let(:collection) { (1..100).to_a }
+  let(:paginate_array_options) { { total_count: 1000 } }
+
+  context 'Using kaminari' do
+    before do
+      ApiPagination.config.paginator = :kaminari
+    end
+
+    after do
+      ApiPagination.config.paginator = ENV['PAGINATOR'].to_sym
+    end
+
+    it 'should accept paginate_array_options option' do
+      expect(Kaminari).to receive(:paginate_array)
+                            .with(collection, paginate_array_options)
+                            .and_call_original
+
+      ApiPagination.paginate(
+        collection,
+        {
+          per_page: 30,
+          paginate_array_options: paginate_array_options
+        }
+      )
+    end
+  end
+end


### PR DESCRIPTION
When collection is an array, we want to pass options which like `total_count: 999` to paginate_array.
So, 
```ruby
paginate  (1..999).to_a, 
          page: 20, 
          per_page: 50, 
          paginate_array_options: { 
            total_count: 999, 
            offset: 9
          }
```