### PR TITLE
Add page header

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ ApiPagination.configure do |config|
 
   # By default, this is set to 'Per-Page'
   config.per_page_header = 'X-Per-Page'
+
+  # Optional : set this to add a header with the current page number.
+  config.page_header = 'X-Page'
 end
 ```
 

--- a/lib/api-pagination/configuration.rb
+++ b/lib/api-pagination/configuration.rb
@@ -4,6 +4,8 @@ module ApiPagination
 
     attr_accessor :per_page_header
 
+    attr_accessor :page_header
+
     def configure(&block)
       yield self
     end
@@ -11,6 +13,7 @@ module ApiPagination
     def initialize
       @total_header    = 'Total'
       @per_page_header = 'Per-Page'
+      @page_header     = nil
     end
 
     def paginator

--- a/lib/grape/pagination.rb
+++ b/lib/grape/pagination.rb
@@ -22,10 +22,12 @@ module Grape
 
           total_header    = ApiPagination.config.total_header
           per_page_header = ApiPagination.config.per_page_header
+          page_header     = ApiPagination.config.page_header
 
           header 'Link',          links.join(', ') unless links.empty?
           header total_header,    ApiPagination.total_from(collection)
           header per_page_header, options[:per_page].to_s
+          header page_header,     options[:page].to_s unless page_header.nil?
 
           return collection
         end

--- a/lib/rails/pagination.rb
+++ b/lib/rails/pagination.rb
@@ -41,10 +41,12 @@ module Rails
 
       total_header    = ApiPagination.config.total_header
       per_page_header = ApiPagination.config.per_page_header
+      page_header     = ApiPagination.config.page_header
 
       headers['Link']          = links.join(', ') unless links.empty?
       headers[total_header]    = ApiPagination.total_from(collection)
       headers[per_page_header] = options[:per_page].to_s
+      headers[page_header]     = options[:page].to_s unless page_header.nil?
 
       return collection
     end

--- a/spec/grape_spec.rb
+++ b/spec/grape_spec.rb
@@ -71,6 +71,7 @@ describe NumbersAPI do
       before do
         ApiPagination.config.total_header    = 'X-Total-Count'
         ApiPagination.config.per_page_header = 'X-Per-Page'
+        ApiPagination.config.page_header     = 'X-Page'
 
         get '/numbers', count: 10
       end
@@ -78,10 +79,12 @@ describe NumbersAPI do
       after do
         ApiPagination.config.total_header    = 'Total'
         ApiPagination.config.per_page_header = 'Per-Page'
+        ApiPagination.config.page_header     = nil
       end
 
       let(:total) { last_response.header['X-Total-Count'].to_i }
       let(:per_page) { last_response.header['X-Per-Page'].to_i }
+      let(:page) { last_response.header['X-Page'].to_i }
 
       it 'should give a X-Total-Count header' do
         headers_keys = last_response.headers.keys
@@ -97,6 +100,13 @@ describe NumbersAPI do
         expect(headers_keys).not_to include('Per-Page')
         expect(headers_keys).to include('X-Per-Page')
         expect(per_page).to eq(10)
+      end
+
+      it 'should give a X-Page header' do
+        headers_keys = last_response.headers.keys
+
+        expect(headers_keys).to include('X-Page')
+        expect(page).to eq(1)
       end
     end
 

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -73,6 +73,7 @@ describe NumbersController, :type => :controller do
       before do
         ApiPagination.config.total_header    = 'X-Total-Count'
         ApiPagination.config.per_page_header = 'X-Per-Page'
+        ApiPagination.config.page_header     = 'X-Page'
 
         get :index, count: 10
       end
@@ -80,10 +81,12 @@ describe NumbersController, :type => :controller do
       after do
         ApiPagination.config.total_header    = 'Total'
         ApiPagination.config.per_page_header = 'Per-Page'
+        ApiPagination.config.page_header     = nil
       end
 
       let(:total) { response.header['X-Total-Count'].to_i }
       let(:per_page) { response.header['X-Per-Page'].to_i }
+      let(:page) { response.header['X-Page'].to_i }
 
       it 'should give a X-Total-Count header' do
         headers_keys = response.headers.keys
@@ -99,6 +102,13 @@ describe NumbersController, :type => :controller do
         expect(headers_keys).not_to include('Per-Page')
         expect(headers_keys).to include('X-Per-Page')
         expect(per_page).to eq(10)
+      end
+
+      it 'should give a X-Page header' do
+        headers_keys = response.headers.keys
+
+        expect(headers_keys).to include('X-Page')
+        expect(page).to eq(1)
       end
     end
   end


### PR DESCRIPTION
Hi,

I wanted to use api-pagination on my API and https://github.com/DanielBlanco/her-kaminari on the project using the API, but the header giving the information about the requested page was missing.

I couldn't find a reference about a W3C spec for this, so I made it optional (to be used with X-Page for example)