### PR TITLE
Use Total Count parameter for Kaminari

### DIFF
--- a/lib/api-pagination.rb
+++ b/lib/api-pagination.rb
@@ -63,7 +63,7 @@ module ApiPagination
         options[:per_page] = Kaminari.config.default_per_page
       end
 
-      collection = Kaminari.paginate_array(collection, paginate_array_options) if collection.is_a?(Array)
+      collection = Kaminari.paginate_array(collection, paginate_array_options) if collection.is_a?(Array) || paginate_array_options[:total_count].present?
       collection.page(options[:page]).per(options[:per_page])
     end
 

--- a/lib/rails/pagination.rb
+++ b/lib/rails/pagination.rb
@@ -2,10 +2,7 @@ module Rails
   module Pagination
     protected
 
-    def paginate(*options_or_collection)
-      options    = options_or_collection.extract_options!
-      collection = options_or_collection.first
-
+    def paginate(collection, options = {})
       return _paginate_collection(collection, options) if collection
 
       collection = options[:json] || options[:xml]
@@ -23,11 +20,9 @@ module Rails
 
     private
 
-    def _paginate_collection(collection, options={})
-      options = {
-        :page     => params[:page],
-        :per_page => (options.delete(:per_page) || params[:per_page])
-      }
+    def _paginate_collection(collection, options = {})
+      options.merge!(page: params[:page], per_page: (options.delete(:per_page) || params[:per_page]))
+
       collection = ApiPagination.paginate(collection, options)
 
       links = (headers['Link'] || "").split(',').map(&:strip)
@@ -39,11 +34,13 @@ module Rails
         links << %(<#{url}?#{new_params.to_param}>; rel="#{k}")
       end
 
+      total_count = options[:paginate_array_options][:total_count] rescue ApiPagination.total_from(collection)
+
       total_header    = ApiPagination.config.total_header
       per_page_header = ApiPagination.config.per_page_header
 
       headers['Link']          = links.join(', ') unless links.empty?
-      headers[total_header]    = ApiPagination.total_from(collection)
+      headers[total_header]    = total_count.to_s
       headers[per_page_header] = options[:per_page].to_s
 
       return collection


### PR DESCRIPTION
This patch allows the use of `paginate_array_options` in `paginate()` when using Kaminari. In the master branch any nested options get erased after the `options_or_collection.extract_options!` line is run, therefore these options never reach `Kaminari.paginate_array()`

This patch also updates the Header for the total as well.