### PR TITLE
Allow running test suite without PAGINATOR set

### DIFF
--- a/spec/api-pagination_spec.rb
+++ b/spec/api-pagination_spec.rb
@@ -10,7 +10,7 @@ describe ApiPagination do
     end
 
     after do
-      ApiPagination.config.paginator = ENV['PAGINATOR'].to_sym
+      ApiPagination.config.paginator = ENV.fetch('PAGINATOR', 'kaminari').to_sym
     end
 
     it 'should accept paginate_array_options option' do


### PR DESCRIPTION
kaminari is the default, so let's assume that. Otherwise, if PAGINATOR
is not set while running the test suite, you will always get a failure
like this:

```
  1) ApiPagination Using kaminari should accept paginate_array_options option
     Failure/Error: ApiPagination.config.paginator = ENV['PAGINATOR'].to_sym
     NoMethodError:
       undefined method `to_sym' for nil:NilClass
     # ./spec/api-pagination_spec.rb:13:in `block (3 levels) in <top (required)>'
```

With this patch applied, you get:

```
$ rspec 
No PAGINATOR set. Defaulting to kaminari. To test against will_paginate, run `PAGINATOR=will_paginate bundle exec rspec`

Randomized with seed 32658
........................................................

Finished in 0.16081 seconds (files took 1.09 seconds to load)
56 examples, 0 failures

Randomized with seed 32658

$ PAGINATOR=will_paginate rspec 

Randomized with seed 22358
.........................................................

Finished in 0.16365 seconds (files took 1.25 seconds to load)
57 examples, 0 failures

Randomized with seed 22358

$ PAGINATOR=kaminari rspec 

Randomized with seed 60733
........................................................

Finished in 0.16405 seconds (files took 1.08 seconds to load)
56 examples, 0 failures

Randomized with seed 60733
```