### PR TITLE
Add support for optional param names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .config
 .yardoc
 .ruby-version
+.ruby-gemset
 Gemfile.lock
 InstalledFiles
 _yardoc

--- a/README.md
+++ b/README.md
@@ -40,8 +40,22 @@ ApiPagination.configure do |config|
   # By default, this is set to 'Per-Page'
   config.per_page_header = 'X-Per-Page'
 
-  # Optional : set this to add a header with the current page number.
+  # Optional: set this to add a header with the current page number.
   config.page_header = 'X-Page'
+
+  # Optional: what parameter should be used to set the page option
+  config.page_param = :page
+  # or
+  config.page_param do |params|
+    params[:page][:number]
+  end
+
+  # Optional: what parameter should be used to set the per page option
+  config.per_page_param = :per_page
+  # or
+  config.per_page_param do |params|
+    params[:page][:size]
+  end
 end
 ```
 

--- a/lib/grape/pagination.rb
+++ b/lib/grape/pagination.rb
@@ -3,9 +3,10 @@ module Grape
     def self.included(base)
       Grape::Endpoint.class_eval do
         def paginate(collection)
-          per_page = params[:per_page] || route_setting(:per_page)
+          per_page = ApiPagination.config.per_page_param(params) || route_setting(:per_page)
+
           options = {
-            :page     => params[:page],
+            :page     => ApiPagination.config.page_param(params),
             :per_page => [per_page, route_setting(:max_per_page)].compact.min
           }
           collection = ApiPagination.paginate(collection, options)

--- a/lib/rails/pagination.rb
+++ b/lib/rails/pagination.rb
@@ -25,8 +25,11 @@ module Rails
 
     def _paginate_collection(collection, options={})
       options = {
-        :page     => params[:page],
-        :per_page => (options.delete(:per_page) || params[:per_page])
+        :page     => ApiPagination.config.page_param(params),
+        :per_page => (
+          options.delete(:per_page) ||
+          ApiPagination.config.per_page_param(params)
+        )
       }
       collection = ApiPagination.paginate(collection, options)
 

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -123,5 +123,82 @@ describe NumbersController, :type => :controller do
 
       after { ApiPagination.config.include_total = true }
     end
+
+    context 'custom page param' do
+      context 'page_param as a symbol' do
+        before do
+          ApiPagination.config.page_param = :foo
+          ApiPagination.config.page_header = 'Page'
+        end
+
+        after do
+          ApiPagination.config.page_param = :page
+          ApiPagination.config.page_header = nil
+        end
+
+        it 'should work' do
+          get :index, :foo => 2, :count => 100
+
+          expect(response.header['Page']).to eq('2')
+        end
+      end
+
+      context 'page_param as a block' do
+        before do
+          ApiPagination.config.page_param do |params|
+            params[:foo][:bar]
+          end
+
+          ApiPagination.config.page_header = 'Page'
+        end
+
+        after do
+          ApiPagination.config.page_param = :page
+          ApiPagination.config.page_header = nil
+        end
+
+        it 'should work' do
+          get :index, :foo => { :bar => 2 }, :count => 100
+
+          expect(response.header['Page']).to eq('2')
+        end
+      end
+    end
+
+    context 'custom per_page param' do
+      context 'per_page_param as a symbol' do
+        before do
+          ApiPagination.config.per_page_param = :foo
+        end
+
+        after do
+          ApiPagination.config.per_page_param = :per_page
+        end
+
+        it 'should work' do
+          get :index_with_no_per_page, :foo => 2, :count => 100
+
+          expect(response.header['Per-Page']).to eq('2')
+        end
+      end
+
+      context 'page_param as a block' do
+        before do
+          ApiPagination.config.per_page_param do |params|
+            params[:foo][:bar]
+          end
+        end
+
+        after do
+          ApiPagination.config.per_page_param = :per_page
+        end
+
+        it 'should work' do
+          get :index_with_no_per_page, :foo => { :bar => 2 }, :count => 100
+
+          expect(response.header['Per-Page']).to eq('2')
+        end
+      end
+    end
   end
 end

--- a/spec/support/numbers_controller.rb
+++ b/spec/support/numbers_controller.rb
@@ -41,6 +41,7 @@ end
 Rails.application.routes.draw do
   resources :numbers, :only => [:index] do
     get :index_with_custom_render, on: :collection
+    get :index_with_no_per_page,   on: :collection
   end
 end
 
@@ -73,6 +74,14 @@ class NumbersController < ActionController::Base
     total   = params.fetch(:count).to_i
     numbers = (1..total).to_a
     numbers = paginate numbers, :per_page => 10
+
+    render json: NumbersSerializer.new(numbers)
+  end
+
+  def index_with_no_per_page
+    total   = params.fetch(:count).to_i
+    numbers = (1..total).to_a
+    numbers = paginate numbers
 
     render json: NumbersSerializer.new(numbers)
   end


### PR DESCRIPTION
**api-pagination** uses `params[:page]` and `params[:per_page]` to set the current page and per-page options in the controller by default. This commit allows user to actually override those and use their own getters or specify the name of the parameter. So they can use for example `params[:page][:number]` for current page by default.

No breaking changes (just one more feature)