### PR TITLE
Fetch per_page from model by default

### DIFF
--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -200,5 +200,47 @@ describe NumbersController, :type => :controller do
         end
       end
     end
+
+    context 'default per page in model' do
+      before do
+        class Fixnum
+          @default_per_page = 6
+          @per_page = 6
+
+          class << self
+            attr_accessor :default_per_page, :per_page
+          end
+        end
+      end
+
+      after do
+        class Fixnum
+          @default_per_page = 25
+          @per_page = 25
+        end
+      end
+
+      it 'should use default per page from model' do
+        get :index_with_no_per_page, count: 100
+
+        expect(response.header['Per-Page']).to eq('6')
+      end
+
+      it 'should not fail if model does not respond to per page' do
+        class Fixnum
+          @default_per_page = nil
+          @per_page = nil
+        end
+
+        get :index_with_no_per_page, count: 100
+
+        expect(response.header['Per-Page']).to eq(
+          case ApiPagination.config.paginator
+          when :kaminari      then Kaminari.config.default_per_page.to_s
+          when :will_paginate then WillPaginate.per_page.to_s
+          end
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
Both kaminari and will_paginate support `per_page` configuration on the model:

```
# kaminari
class User < ActiveRecord::Base
  paginates_per 50
end
```

```
# will_paginate
class User < ActiveRecord::Base
  self.per_page = 50
end
```

This PR is adding a functionality to `api-pagination` to use the values from model by default, so the `per_page` doesn't have to be same for all resources or overridden in controller.

```
def index
  @users = User.all
  paginate @users # per_page will be 50
end
```

Fixes #48 