### PR TITLE
Fix version number of api-pagination for grape in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ In your `Gemfile`:
 ```ruby
 # Requires Rails (Rails-API is also supported), or Grape
 # v0.10.0 or later. If you're on an earlier version of
-# Grape, use api-pagination 3.x
+# Grape, use api-pagination v3.0.2.
 gem 'rails', '>= 3.0.0'
 gem 'rails-api'
 gem 'grape', '>= 0.10.0'


### PR DESCRIPTION
I tried and found that `api-pagination` v3.1.0+ does not work with `grape` v0.9.0 or earlier.