### PR TITLE
Set default paginator in ENV so specs don't fail without it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: ruby
 sudo: false
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.0
   - 2.2.0
   - 2.3.0
 script: bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.2.0
-  - 2.3.0
+  - 2.2
+  - 2.3
 script: bundle exec rspec
 env:
   - PAGINATOR=kaminari

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.2
-  - 2.3
+  - 2.2.5
+  - 2.3.1
 script: bundle exec rspec
 env:
   - PAGINATOR=kaminari

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,14 +2,13 @@ require 'support/numbers_controller'
 require 'support/numbers_api'
 require 'api-pagination'
 
-if ENV['PAGINATOR']
-  require ENV['PAGINATOR']
-  ApiPagination.config.paginator = ENV['PAGINATOR'].to_sym
-else
+if ENV['PAGINATOR'].nil?
   warn 'No PAGINATOR set. Defaulting to kaminari. To test against will_paginate, run `PAGINATOR=will_paginate bundle exec rspec`'
-  require 'kaminari'
-  ApiPagination.config.paginator = :kaminari
+  ENV['PAGINATOR'] = 'kaminari'
 end
+
+require ENV['PAGINATOR']
+ApiPagination.config.paginator = ENV['PAGINATOR'].to_sym
 
 require 'will_paginate/array'
 


### PR DESCRIPTION
Following the discussion in #55, since it hadn't been touched in months, I implemented the suggested solution so I could get my local specs passing.