### PR TITLE
Take total_count option when kaminari used

### DIFF
--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -201,6 +201,52 @@ describe NumbersController, :type => :controller do
       end
     end
 
+    context 'paginate array options' do
+      shared_examples 'properly set Total header' do
+        let(:params) do
+          {
+            paginate_array_total_count: paginate_array_total_count,
+            count: count,
+          }
+        end
+
+        specify do
+          get :index_with_paginate_array_options, params
+          expect(response.header['Total'].to_i).to eq total_header
+        end
+      end
+
+      context 'kaminari' do
+        around do |example|
+          paginator = ApiPagination.config.paginator
+          ApiPagination.config.paginator = :kaminari
+          example.run
+          ApiPagination.config.paginator = paginator
+        end
+
+        it_should_behave_like 'properly set Total header' do
+          let(:paginate_array_total_count) { 300 }
+          let(:total_header) { 300 }
+          let(:count) { 50 }
+        end
+      end
+
+      context 'will_paginate' do
+        around do |example|
+          paginator = ApiPagination.config.paginator
+          ApiPagination.config.paginator = :will_paginate
+          example.run
+          ApiPagination.config.paginator = paginator
+        end
+
+        it_should_behave_like 'properly set Total header' do
+          let(:paginate_array_total_count) { 300 }
+          let(:total_header) { 50 }
+          let(:count) { 50 }
+        end
+      end
+    end
+
     context 'default per page in model' do
       before do
         class Fixnum

--- a/spec/support/numbers_controller.rb
+++ b/spec/support/numbers_controller.rb
@@ -40,8 +40,11 @@ end
 
 Rails.application.routes.draw do
   resources :numbers, :only => [:index] do
-    get :index_with_custom_render, on: :collection
-    get :index_with_no_per_page,   on: :collection
+    collection do
+      get :index_with_custom_render
+      get :index_with_no_per_page
+      get :index_with_paginate_array_options
+    end
   end
 end
 
@@ -82,6 +85,15 @@ class NumbersController < ActionController::Base
     total   = params.fetch(:count).to_i
     numbers = (1..total).to_a
     numbers = paginate numbers
+
+    render json: NumbersSerializer.new(numbers)
+  end
+
+  def index_with_paginate_array_options
+    count = params.fetch(:count).to_i
+    total_count = params.fetch(:paginate_array_total_count).to_i
+    numbers = (1..count).to_a
+    numbers = paginate numbers, paginate_array_options: {total_count: total_count}
 
     render json: NumbersSerializer.new(numbers)
   end


### PR DESCRIPTION
The PR allow to specify total count of paginated array when kaminari used as a paginator. See more [here](https://github.com/amatsuda/kaminari#paginating-a-generic-array-object). 

The PR similar to https://github.com/davidcelis/api-pagination/pull/50, but in addition has test coverage.