### PR TITLE
Add Rails 5 support

### DIFF
--- a/lib/api-pagination/hooks.rb
+++ b/lib/api-pagination/hooks.rb
@@ -1,13 +1,11 @@
 begin; require 'rails'; rescue LoadError; end
-if defined?(ActionController::Base)
-  require 'rails/pagination'
-  ActionController::Base.send(:include, Rails::Pagination)
-end
-
 begin; require 'rails-api'; rescue LoadError; end
-if defined?(ActionController::API)
+if defined?(Rails)
   require 'rails/pagination'
-  ActionController::API.send(:include, Rails::Pagination)
+
+  ActiveSupport.on_load(:action_controller) do
+    ApiPagination::Hooks.rails_parent_controller.send(:include, Rails::Pagination)
+  end
 end
 
 begin; require 'grape'; rescue LoadError; end
@@ -27,4 +25,16 @@ unless defined?(Kaminari) || defined?(WillPaginate::CollectionMethods)
     gem 'kaminari'
     gem 'will_paginate'
   WARNING
+end
+
+module ApiPagination
+  module Hooks
+    def self.rails_parent_controller
+      if Gem::Version.new(Rails.version) >= Gem::Version.new('5') || defined?(ActionController::API)
+        ActionController::API
+      else
+        ActionController::Base
+      end
+    end
+  end
 end

--- a/lib/api-pagination/version.rb
+++ b/lib/api-pagination/version.rb
@@ -1,7 +1,7 @@
 module ApiPagination
   class Version
     MAJOR = 4
-    MINOR = 4
+    MINOR = 5
     PATCH = 0
 
     def self.to_s

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -13,7 +13,7 @@ describe NumbersController, :type => :controller do
     let(:per_page) { response.headers['Per-Page'].to_i }
 
     context 'without enough items to give more than one page' do
-      before { get :index, :count => 10 }
+      before { get :index, params: {count: 10} }
 
       it 'should not paginate' do
         expect(response.headers.keys).not_to include('Link')
@@ -34,26 +34,26 @@ describe NumbersController, :type => :controller do
     end
 
     context 'with existing Link headers' do
-      before { get :index, :count => 30, :with_headers => true }
+      before { get :index, params: {count: 30, with_headers: true} }
 
       it_behaves_like 'an endpoint with existing Link headers'
     end
 
     context 'with enough items to paginate' do
       context 'when on the first page' do
-        before { get :index, :count => 100 }
+        before { get :index, params: {count: 100} }
 
         it_behaves_like 'an endpoint with a first page'
       end
 
       context 'when on the last page' do
-        before { get :index, :count => 100, :page => 10 }
+        before { get :index, params: {count: 100, page: 10} }
 
         it_behaves_like 'an endpoint with a last page'
       end
 
       context 'when somewhere comfortably in the middle' do
-        before { get :index, :count => 100, :page => 2 }
+        before { get :index, params: {count: 100, page: 2} }
 
         it_behaves_like 'an endpoint with a middle page'
       end
@@ -61,7 +61,7 @@ describe NumbersController, :type => :controller do
 
     context 'providing a block' do
       it 'yields to the block instead of implicitly rendering' do
-        get :index_with_custom_render, :count => 100
+        get :index_with_custom_render, params: {count: 100}
 
         json = { numbers: (1..10).map { |n| { number: n } } }.to_json
 
@@ -75,7 +75,7 @@ describe NumbersController, :type => :controller do
         ApiPagination.config.per_page_header = 'X-Per-Page'
         ApiPagination.config.page_header     = 'X-Page'
 
-        get :index, count: 10
+        get :index, params: {count: 10}
       end
 
       after do
@@ -116,7 +116,7 @@ describe NumbersController, :type => :controller do
       before { ApiPagination.config.include_total = false }
 
       it 'should not include a Total header' do
-        get :index, count: 10
+        get :index, params: {count: 10}
 
         expect(response.header['Total']).to be_nil
       end
@@ -137,7 +137,7 @@ describe NumbersController, :type => :controller do
         end
 
         it 'should work' do
-          get :index, :foo => 2, :count => 100
+          get :index, params: {foo: 2, count: 100}
 
           expect(response.header['Page']).to eq('2')
         end
@@ -158,7 +158,7 @@ describe NumbersController, :type => :controller do
         end
 
         it 'should work' do
-          get :index, :foo => { :bar => 2 }, :count => 100
+          get :index, params: {foo: {bar:  2}, count: 100}
 
           expect(response.header['Page']).to eq('2')
         end
@@ -176,7 +176,7 @@ describe NumbersController, :type => :controller do
         end
 
         it 'should work' do
-          get :index_with_no_per_page, :foo => 2, :count => 100
+          get :index_with_no_per_page, params: {foo: 2, count: 100}
 
           expect(response.header['Per-Page']).to eq('2')
         end
@@ -194,7 +194,7 @@ describe NumbersController, :type => :controller do
         end
 
         it 'should work' do
-          get :index_with_no_per_page, :foo => { :bar => 2 }, :count => 100
+          get :index_with_no_per_page, params: {foo: {bar: 2}, count: 100}
 
           expect(response.header['Per-Page']).to eq('2')
         end
@@ -211,7 +211,7 @@ describe NumbersController, :type => :controller do
         end
 
         specify do
-          get :index_with_paginate_array_options, params
+          get :index_with_paginate_array_options, params: params
           expect(response.header['Total'].to_i).to eq total_header
         end
       end
@@ -267,7 +267,7 @@ describe NumbersController, :type => :controller do
       end
 
       it 'should use default per page from model' do
-        get :index_with_no_per_page, count: 100
+        get :index_with_no_per_page, params: {count: 100}
 
         expect(response.header['Per-Page']).to eq('6')
       end
@@ -278,7 +278,7 @@ describe NumbersController, :type => :controller do
           @per_page = nil
         end
 
-        get :index_with_no_per_page, count: 100
+        get :index_with_no_per_page, params: {count: 100}
 
         expect(response.header['Per-Page']).to eq(
           case ApiPagination.config.paginator

--- a/spec/support/numbers_controller.rb
+++ b/spec/support/numbers_controller.rb
@@ -1,4 +1,5 @@
 require 'action_controller'
+require 'api-pagination/hooks'
 require 'ostruct'
 
 module Rails
@@ -58,7 +59,7 @@ class NumbersSerializer
   end
 end
 
-class NumbersController < ActionController::Base
+class NumbersController < ApiPagination::Hooks.rails_parent_controller
   include Rails.application.routes.url_helpers
 
   def index


### PR DESCRIPTION
In Rails 5:

* The parent controller for the API is `ActionController::API` not `ActionController::Base`
* When extending the ActionController it needs to be nested in `ActiveSupport.on_load`