### PR TITLE
Total count header plays nice with Rack::Handler::Webrick

### DIFF
--- a/lib/rails/pagination.rb
+++ b/lib/rails/pagination.rb
@@ -46,7 +46,7 @@ module Rails
       headers['Link'] = links.join(', ') unless links.empty?
       headers[per_page_header] = options[:per_page].to_s
       headers[page_header] = options[:page].to_s unless page_header.nil?
-      headers[total_header] = total_count(collection, options) if include_total
+      headers[total_header] = total_count(collection, options).to_s if include_total
 
       return collection
     end

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -212,6 +212,8 @@ describe NumbersController, :type => :controller do
 
         specify do
           get :index_with_paginate_array_options, params: params
+
+          expect(response.header['Total']).to be_kind_of(String)
           expect(response.header['Total'].to_i).to eq total_header
         end
       end


### PR DESCRIPTION
Encountered an error within `Rack::Handler::Webrick`. Apparently that handler (which would be default for many stock rails installations in development) wants to make sure that the contents of each value in the headers hash is not multiline, and assumes that the value of each header is a string. The other values we set for headers are coerced to string, but not `Total`. So we need to make sure it's a string for compatibility with downstream handlers.

The error `Undefined method "split" for 23:fixnum` was coming up if i supplied `total_count` to `paginate_array_options` as an integer. When I tried supplying a string, then the call to `Kaminari.paginate_array` would fail as Kaminari expects an integer value.

You can see where this error was coming up in the following capture. 

```
From: /Users/tastycode/.rbenv/versions/2.1.8/lib/ruby/gems/2.1.0/gems/rack-1.5.5/lib/rack/handler/webrick.rb @ line 72 Rack::Handler::WEBrick#service:

    67:               # Since WEBrick won't accept repeated headers,
    68:               # merge the values per RFC 1945 section 4.2.
    69:               begin
    70:                 res[k] = vs.split("\n").join(", ")
    71:               rescue => e
 => 72:                 binding.pry
    73:               end
    74:             end
    75:           }
    76:           body.each { |part|
    77:             res.body << part

[6] pry(#<Rack::Handler::WEBrick>)> k
=> "Total"
[7] pry(#<Rack::Handler::WEBrick>)> vs
=> 23
[8] pry(#<Rack::Handler::WEBrick>)> exit
```

You may also consider porting this to the `Grape` pagination handler.