### PR TITLE
Fix typo in link to active_model_serializers

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ class MoviesController < ApplicationController
 end
 ```
 
-This will pull your collection from the `json` or `xml` option, paginate it for you using `params[:page]` and `params[:per_page]`, render Link headers, and call `ActionController::Base#render` with whatever you passed to `paginate`. This should work well with [ActiveModel::Serializers](https://github.com/rails-api/active_model-serializers). However, if you need more control over what is done with your paginated collection, you can pass the collection directly to `paginate` to receive a paginated collection and have your headers set. Then, you can pass that paginated collection to a serializer or do whatever you want with it:
+This will pull your collection from the `json` or `xml` option, paginate it for you using `params[:page]` and `params[:per_page]`, render Link headers, and call `ActionController::Base#render` with whatever you passed to `paginate`. This should work well with [ActiveModel::Serializers](https://github.com/rails-api/active_model_serializers). However, if you need more control over what is done with your paginated collection, you can pass the collection directly to `paginate` to receive a paginated collection and have your headers set. Then, you can pass that paginated collection to a serializer or do whatever you want with it:
 
 ```ruby
 class MoviesController < ApplicationController


### PR DESCRIPTION
clicked the link to `rails-api/active_model_serializers` and noticed it was broken - just a quick fix to the correct url (the second underscore was a dash instead by mistake).