### PR TITLE
Kaminari 1.0 last_page? behavior fix

### DIFF
--- a/lib/api-pagination.rb
+++ b/lib/api-pagination.rb
@@ -25,7 +25,7 @@ module ApiPagination
           pages[:prev]  = collection.current_page - 1
         end
 
-        unless collection.last_page?
+        unless collection.last_page? || (ApiPagination.config.paginator == :kaminari && collection.out_of_range?)
           pages[:last] = collection.total_pages
           pages[:next] = collection.current_page + 1
         end

--- a/spec/api-pagination_spec.rb
+++ b/spec/api-pagination_spec.rb
@@ -26,5 +26,15 @@ describe ApiPagination do
         }
       )
     end
+
+    describe '.pages_from' do
+      subject { described_class.pages_from collection }
+
+      context 'on empty collection' do
+        let(:collection) { ApiPagination.paginate [], page: 1 }
+
+        it { is_expected.to be_empty }
+      end
+    end
   end
 end


### PR DESCRIPTION
New kaminari 1.0's `last_page?` method behavior is changed: now it returns false if current page is bigger then total pages.
This breaks our API: `Link` header with `next` and `last` urls appears even on the empty collection (because `current_page` is always 1 and `total_pages` is always 0).

This pull-request adds work-around keeping in mind that WillPaginate does not have `#out_of_range?` method.