### PR TITLE
Adding will_paginate support for total_entries being passed in as an option

### DIFF
--- a/lib/api-pagination.rb
+++ b/lib/api-pagination.rb
@@ -60,7 +60,7 @@ module ApiPagination
       if defined?(Sequel::Dataset) && collection.kind_of?(Sequel::Dataset)
         collection.paginate(options[:page], options[:per_page])
       else
-        collection.paginate(:page => options[:page], :per_page => options[:per_page])
+        collection.paginate(options)
       end
     end
 

--- a/spec/api-pagination_spec.rb
+++ b/spec/api-pagination_spec.rb
@@ -1,39 +1,65 @@
 require 'spec_helper'
 
 describe ApiPagination do
-  let(:collection) { (1..100).to_a }
-  let(:paginate_array_options) { { total_count: 1000 } }
+  let(:collection) {(1..100).to_a}
+  let(:paginate_array_options) {{ total_count: 1000 }}
 
-  context 'Using kaminari' do
-    before do
-      ApiPagination.config.paginator = :kaminari
+  describe "#paginate" do
+    context 'Using kaminari' do
+      before do
+        ApiPagination.config.paginator = :kaminari
+      end
+
+      after do
+        ApiPagination.config.paginator = ENV['PAGINATOR'].to_sym
+      end
+
+      it 'should accept paginate_array_options option' do
+        expect(Kaminari).to receive(:paginate_array)
+                              .with(collection, paginate_array_options)
+                              .and_call_original
+
+        ApiPagination.paginate(
+          collection,
+          {
+            per_page:               30,
+            paginate_array_options: paginate_array_options
+          }
+        )
+      end
+
+      describe '.pages_from' do
+        subject {described_class.pages_from collection}
+
+        context 'on empty collection' do
+          let(:collection) {ApiPagination.paginate [], page: 1}
+
+          it {is_expected.to be_empty}
+        end
+      end
     end
 
-    after do
-      ApiPagination.config.paginator = ENV['PAGINATOR'].to_sym
-    end
+    context 'Using will_paginate' do
+      before do
+        ApiPagination.config.paginator = :will_paginate
+      end
 
-    it 'should accept paginate_array_options option' do
-      expect(Kaminari).to receive(:paginate_array)
-                            .with(collection, paginate_array_options)
-                            .and_call_original
+      after do
+        ApiPagination.config.paginator = ENV['PAGINATOR'].to_sym
+      end
 
-      ApiPagination.paginate(
-        collection,
-        {
-          per_page: 30,
-          paginate_array_options: paginate_array_options
-        }
-      )
-    end
+      context 'passing in total_entries in options' do
+        it 'should set total_entries using the passed in value' do
+          paginated_collection = ApiPagination.paginate(collection, total_entries: 3000)
+          expect(paginated_collection.total_entries).to eq(3000)
+        end
+      end
 
-    describe '.pages_from' do
-      subject { described_class.pages_from collection }
-
-      context 'on empty collection' do
-        let(:collection) { ApiPagination.paginate [], page: 1 }
-
-        it { is_expected.to be_empty }
+      context 'passing in collection only' do
+        it 'should set total_entries using the size of the collection ' do
+          paginated_collection = ApiPagination.paginate(collection)
+          expect(paginated_collection.total_entries).to eq(100)
+        end
       end
     end
   end


### PR DESCRIPTION
# Summary
ApiPagination#paginate takes `options`. These options are then part of paginating the collection using the WillPaginate::Collection#paginate method. Only `page` and `per_page` used to be passed through all the way down to the will_paginate method. This PR makes sure that we simply pass through all options passed in. 

This specifically adds support for a total_entries size different from the size of the collection.