### PR TITLE
remove the extra db query 

### DIFF
--- a/lib/api-pagination.rb
+++ b/lib/api-pagination.rb
@@ -81,7 +81,11 @@ module ApiPagination
     end
 
     def detect_model(collection)
-      collection.first.class
+      if collection.respond_to?(:table_name)
+        collection.table_name.singularize.capitalize.constantize
+      else
+        collection.first.class
+      end
     end
   end
 end


### PR DESCRIPTION
Remove the extra db query for ActiveRecord::Associations::CollectionProxy and ActiveRecord::Relation

Right now, to check the default per page count, it uses collection.first.class to get the model class. This will cause an extra db request. It's better to remove that. And in test, it use an array of integers as the collection. So I check if the collection respond_to :table_name method first to decide which way to use to get the model class. 