### PR TITLE
Fix regression for multi word classes

### DIFF
--- a/lib/api-pagination.rb
+++ b/lib/api-pagination.rb
@@ -82,7 +82,7 @@ module ApiPagination
 
     def detect_model(collection)
       if collection.respond_to?(:table_name)
-        collection.table_name.singularize.capitalize.constantize
+        collection.table_name.classify.constantize
       else
         collection.first.class
       end


### PR DESCRIPTION
Fix for issue #83 
Use classify instead of `singularize.capitalize` to work in all cases.