### PR TITLE
[wip] Empty collections are generating next and last links

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in api_pagination.gemspec
 gemspec
 
-gem 'kaminari', "~> 0.16.0", require: false
+gem 'kaminari', "~> 1.1.1", require: false
 gem 'will_paginate', require: false
 
 gem 'sqlite3', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in api_pagination.gemspec
 gemspec
 
-gem 'kaminari', require: false
+gem 'kaminari', "~> 0.16.0", require: false
 gem 'will_paginate', require: false
 
 gem 'sqlite3', require: false

--- a/spec/grape_spec.rb
+++ b/spec/grape_spec.rb
@@ -10,6 +10,27 @@ describe NumbersAPI do
     let(:total) { last_response.headers['Total'].to_i }
     let(:per_page) { last_response.headers['Per-Page'].to_i }
 
+    context 'with empty collection' do
+      before { get '/numbers', :count => 0 }
+
+      it 'should not paginate' do
+        expect(last_response.headers.keys).not_to include('Link')
+      end
+
+      it 'should give a Total header' do
+        expect(total).to eq(0)
+      end
+
+      it 'should give a Per-Page header' do
+        expect(per_page).to eq(10)
+      end
+
+      it 'should list all numbers in the response body' do
+        body = '[]'
+        expect(last_response.body).to eq(body)
+      end
+    end
+
     context 'without enough items to give more than one page' do
       before { get '/numbers', :count => 10 }
 
@@ -26,7 +47,7 @@ describe NumbersAPI do
       end
 
       it 'should list all numbers in the response body' do
-        body = '[1,2,3,4,5,6,7,8,9,10]'
+        body = '[0,1,2,3,4,5,6,7,8,9]'
         expect(last_response.body).to eq(body)
       end
     end
@@ -60,7 +81,7 @@ describe NumbersAPI do
         before { get '/numbers', :count => 100, :per_page => 30 }
 
         it 'should not go above the max_per_page_limit' do
-          body = '[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25]'
+          body = '[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24]'
 
           expect(last_response.body).to eq(body)
         end

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -12,6 +12,27 @@ describe NumbersController, :type => :controller do
     let(:total) { response.headers['Total'].to_i }
     let(:per_page) { response.headers['Per-Page'].to_i }
 
+    context 'with empty collection' do
+      before { get :index, params: {count: 0} }
+
+      it 'should not paginate' do
+        expect(response.headers.keys).not_to include('Link')
+      end
+
+      it 'should give a Total header' do
+        expect(total).to eq(0)
+      end
+
+      it 'should give a Per-Page header' do
+        expect(per_page).to eq(10)
+      end
+
+      it 'should return an empty array' do
+        body = '[]'
+        expect(response.body).to eq(body)
+      end
+    end
+
     context 'without enough items to give more than one page' do
       before { get :index, params: {count: 10} }
 
@@ -28,7 +49,7 @@ describe NumbersController, :type => :controller do
       end
 
       it 'should list all numbers in the response body' do
-        body = '[1,2,3,4,5,6,7,8,9,10]'
+        body = '[0,1,2,3,4,5,6,7,8,9]'
         expect(response.body).to eq(body)
       end
     end
@@ -63,7 +84,7 @@ describe NumbersController, :type => :controller do
       it 'yields to the block instead of implicitly rendering' do
         get :index_with_custom_render, params: {count: 100}
 
-        json = { numbers: (1..10).map { |n| { number: n } } }.to_json
+        json = { numbers: (0...10).map { |n| { number: n } } }.to_json
 
         expect(response.body).to eq(json)
       end

--- a/spec/support/numbers_api.rb
+++ b/spec/support/numbers_api.rb
@@ -5,7 +5,7 @@ class NumbersAPI < Grape::API
   format :json
 
   desc 'Return some paginated set of numbers'
-  paginate :per_page => 10, :max_per_page => 25 
+  paginate :per_page => 10, :max_per_page => 25
   params do
     requires :count, :type => Integer
     optional :with_headers, :default => false, :type => Boolean
@@ -18,6 +18,6 @@ class NumbersAPI < Grape::API
       header 'Link', %(<#{url}?#{query.to_query}>; rel="without")
     end
 
-    paginate (1..params[:count]).to_a
+    paginate (0...params[:count]).to_a
   end
 end

--- a/spec/support/numbers_controller.rb
+++ b/spec/support/numbers_controller.rb
@@ -71,7 +71,7 @@ class NumbersController < ApiPagination::Hooks.rails_parent_controller
       headers['Link'] = %(<#{numbers_url}?#{query.to_param}>; rel="without")
     end
 
-    paginate :json => (1..total).to_a, :per_page => 10
+    paginate :json => (0...total).to_a, :per_page => 10
   end
 
   def index_with_custom_render

--- a/spec/support/numbers_controller.rb
+++ b/spec/support/numbers_controller.rb
@@ -76,7 +76,7 @@ class NumbersController < ApiPagination::Hooks.rails_parent_controller
 
   def index_with_custom_render
     total   = params.fetch(:count).to_i
-    numbers = (1..total).to_a
+    numbers = (0...total).to_a
     numbers = paginate numbers, :per_page => 10
 
     render json: NumbersSerializer.new(numbers)

--- a/spec/support/numbers_controller.rb
+++ b/spec/support/numbers_controller.rb
@@ -84,7 +84,7 @@ class NumbersController < ApiPagination::Hooks.rails_parent_controller
 
   def index_with_no_per_page
     total   = params.fetch(:count).to_i
-    numbers = (1..total).to_a
+    numbers = (0...total).to_a
     numbers = paginate numbers
 
     render json: NumbersSerializer.new(numbers)
@@ -93,7 +93,7 @@ class NumbersController < ApiPagination::Hooks.rails_parent_controller
   def index_with_paginate_array_options
     count = params.fetch(:count).to_i
     total_count = params.fetch(:paginate_array_total_count).to_i
-    numbers = (1..count).to_a
+    numbers = (0...count).to_a
     numbers = paginate numbers, paginate_array_options: {total_count: total_count}
 
     render json: NumbersSerializer.new(numbers)

--- a/spec/support/shared_examples/first_page.rb
+++ b/spec/support/shared_examples/first_page.rb
@@ -20,7 +20,7 @@ shared_examples 'an endpoint with a first page' do
   end
 
   it 'should list the first page of numbers in the response body' do
-    body = '[1,2,3,4,5,6,7,8,9,10]'
+    body = '[0,1,2,3,4,5,6,7,8,9]'
     if defined?(response)
       expect(response.body).to eq(body)
     else

--- a/spec/support/shared_examples/last_page.rb
+++ b/spec/support/shared_examples/last_page.rb
@@ -20,7 +20,7 @@ shared_examples 'an endpoint with a last page' do
   end
 
   it 'should list the last page of numbers in the response body' do
-    body = '[91,92,93,94,95,96,97,98,99,100]'
+    body = '[90,91,92,93,94,95,96,97,98,99]'
 
     if defined?(response)
       expect(response.body).to eq(body)

--- a/spec/support/shared_examples/middle_page.rb
+++ b/spec/support/shared_examples/middle_page.rb
@@ -11,7 +11,7 @@ shared_examples 'an endpoint with a middle page' do
   end
 
   it 'should list a middle page of numbers in the response body' do
-    body = '[11,12,13,14,15,16,17,18,19,20]'
+    body = '[10,11,12,13,14,15,16,17,18,19]'
 
     if defined?(response)
       expect(response.body).to eq(body)


### PR DESCRIPTION
After the upgrade of Kaminari from version 0.16 to 1.1.1, we have noticed that an extra `next` link is generated for empty collections.

I am trying to reproduce the issue an isolated environment, prepare some failing tests and hopefully create a fix for this behavior.