### PR TITLE
add config option for base_url

### DIFF
--- a/lib/api-pagination/configuration.rb
+++ b/lib/api-pagination/configuration.rb
@@ -8,6 +8,8 @@ module ApiPagination
 
     attr_accessor :include_total
 
+    attr_accessor :base_url
+
     def configure(&block)
       yield self
     end
@@ -17,6 +19,7 @@ module ApiPagination
       @per_page_header = 'Per-Page'
       @page_header     = nil
       @include_total   = true
+      @base_url   = nil
     end
 
     ['page', 'per_page'].each do |param_name|

--- a/lib/rails/pagination.rb
+++ b/lib/rails/pagination.rb
@@ -29,8 +29,8 @@ module Rails
 
       collection = ApiPagination.paginate(collection, options)
 
-      links = (headers['Link'] || "").split(',').map(&:strip)
-      url   = request.original_url.sub(/\?.*$/, '')
+      links = (headers['Link'] || '').split(',').map(&:strip)
+      url   = base_url + request.original_fullpath.sub(/\?.*$/, '')
       pages = ApiPagination.pages_from(collection)
 
       pages.each do |k, v|
@@ -58,5 +58,10 @@ module Rails
       end
       total_count || ApiPagination.total_from(collection)
     end
+
+    def base_url
+      ApiPagination.config.base_url || request.base_url
+    end
+
   end
 end

--- a/lib/rails/pagination.rb
+++ b/lib/rails/pagination.rb
@@ -30,7 +30,7 @@ module Rails
       collection = ApiPagination.paginate(collection, options)
 
       links = (headers['Link'] || '').split(',').map(&:strip)
-      url   = base_url + request.original_fullpath.sub(/\?.*$/, '')
+      url   = base_url + request.path_info
       pages = ApiPagination.pages_from(collection)
 
       pages.each do |k, v|

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -74,19 +74,23 @@ describe NumbersController, :type => :controller do
         ApiPagination.config.total_header    = 'X-Total-Count'
         ApiPagination.config.per_page_header = 'X-Per-Page'
         ApiPagination.config.page_header     = 'X-Page'
+        ApiPagination.config.base_url        = 'http://guybrush:3000'
 
-        get :index, params: {count: 10}
+        get :index, params: params
       end
 
       after do
         ApiPagination.config.total_header    = 'Total'
         ApiPagination.config.per_page_header = 'Per-Page'
         ApiPagination.config.page_header     = nil
+        ApiPagination.config.base_url        = nil
       end
 
+      let(:params) { { count: 10 } }
       let(:total) { response.header['X-Total-Count'].to_i }
       let(:per_page) { response.header['X-Per-Page'].to_i }
       let(:page) { response.header['X-Page'].to_i }
+      let(:link) { response.header['Link'] }
 
       it 'should give a X-Total-Count header' do
         headers_keys = response.headers.keys
@@ -109,6 +113,15 @@ describe NumbersController, :type => :controller do
 
         expect(headers_keys).to include('X-Page')
         expect(page).to eq(1)
+      end
+
+      context 'with paginated result' do
+        let(:params) { { count: 20 } }
+        it 'should use custom base_url in the Link header' do
+
+          expect(response.headers['Link']).to eq(
+            '<http://guybrush:3000/numbers?count=20&page=2>; rel="last", <http://guybrush:3000/numbers?count=20&page=2>; rel="next"')
+        end
       end
     end
 


### PR DESCRIPTION
It can be useful to configure a hardcoded base url to be used in the headers of api pagination. 
In case the application is reachable at multiple urls and caching is used, all users get will receive the header with the hostname that was used in the first request. 
This can be undesireable because the application might not be reachable for everyone under that hostname. 
