### PR TITLE
Better behavior for #detect_model

### DIFF
--- a/api-pagination.gemspec
+++ b/api-pagination.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'railties', '>= 5.0.0'
   s.add_development_dependency 'actionpack', '>= 5.0.0'
   s.add_development_dependency 'sequel', '>= 4.9.0'
-  s.add_development_dependency 'activerecord-nulldb-adapter', '>= 0.3.8'
+  s.add_development_dependency 'activerecord-nulldb-adapter', '>= 0.3.9'
 end

--- a/api-pagination.gemspec
+++ b/api-pagination.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'railties', '>= 3.0.0'
   s.add_development_dependency 'actionpack', '>= 3.0.0'
   s.add_development_dependency 'sequel', '>= 4.9.0'
+  s.add_development_dependency 'activerecord-nulldb-adapter', '>= 0.3.8'
 end

--- a/lib/api-pagination.rb
+++ b/lib/api-pagination.rb
@@ -81,8 +81,8 @@ module ApiPagination
     end
 
     def detect_model(collection)
-      if collection.respond_to?(:table_name)
-        collection.table_name.classify.constantize
+      if collection.respond_to?(:klass)
+        collection.klass
       else
         collection.first.class
       end

--- a/lib/api-pagination.rb
+++ b/lib/api-pagination.rb
@@ -68,24 +68,23 @@ module ApiPagination
 
     def get_default_per_page_for_kaminari(collection)
       default = Kaminari.config.default_per_page
-      detect_model(collection).default_per_page || default
-    rescue
-      default
+      extract_per_page_from_model(collection, :default_per_page) || default
     end
 
     def default_per_page_for_will_paginate(collection)
       default = WillPaginate.per_page
-      detect_model(collection).per_page || default
-    rescue
-      default
+      extract_per_page_from_model(collection, :per_page) || default
     end
 
-    def detect_model(collection)
-      if collection.respond_to?(:klass)
+    def extract_per_page_from_model(collection, accessor)
+      klass = if collection.respond_to?(:klass)
         collection.klass
       else
         collection.first.class
       end
+
+      return unless klass.respond_to?(accessor)
+      klass.send(accessor)
     end
   end
 end

--- a/spec/active_record_spec.rb
+++ b/spec/active_record_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+require 'support/active_record/foo'
+require 'nulldb_rspec'
+
+ActiveRecord::Base.establish_connection(
+  adapter: :nulldb,
+  schema: 'support/active_record/schema'
+)
+
+describe 'using kaminari with active_record' do
+  let(:collection) { Foo.all }
+  let(:per_page) { 5 }
+
+  it 'produces correct sql for first page' do
+    paginated_sql = ApiPagination.paginate(collection, per_page: per_page)
+                                 .to_sql
+
+    expect(paginated_sql).to eql(Foo.limit(per_page).offset(0).to_sql)
+  end
+end

--- a/spec/active_record_spec.rb
+++ b/spec/active_record_spec.rb
@@ -11,14 +11,15 @@ NullDB.configure { |ndb| def ndb.project_root; Dir.pwd; end; }
 
 shared_examples 'produces_correct_sql' do 
   it 'produces correct sql for first page' do
-    paginated_sql = ApiPagination.paginate(collection, per_page: per_page)
-    .to_sql
-    expect(paginated_sql).to eql(Foo.limit(per_page).offset(0).to_sql)
+    allow(collection).to receive(:count).and_return(collection_size)
+    paginated_sql, _ = ApiPagination.paginate(collection, per_page: per_page)
+    expect(paginated_sql.to_sql).to eql(Foo.limit(per_page).offset(0).to_sql)
   end
 end
 
 describe 'ActiveRecord Support' do 
   let(:collection) { Foo.all }
+  let(:collection_size) { 50 }
   let(:per_page) { 5 }
   
   if ApiPagination.config.paginator == :will_paginate
@@ -29,16 +30,19 @@ describe 'ActiveRecord Support' do
     include_examples 'produces_correct_sql'
   end
 
-  context 'reflections' do
-    it 'invokes the correct methods to determine type' do 
-      expect(collection).to receive(:klass).at_least(:once)
-                                           .and_call_original
-      ApiPagination.paginate(collection)
-    end
 
-    it 'does not fail if table name is not snake cased class name' do
-      allow(collection).to receive(:table_name).and_return(SecureRandom.uuid)
-      expect { ApiPagination.paginate(collection) }.to_not raise_error
+  if ApiPagination.config.paginator != :pagy
+    context 'reflections' do
+      it 'invokes the correct methods to determine type' do 
+        expect(collection).to receive(:klass).at_least(:once)
+                                             .and_call_original
+        ApiPagination.paginate(collection)
+      end
+
+      it 'does not fail if table name is not snake cased class name' do
+        allow(collection).to receive(:table_name).and_return(SecureRandom.uuid)
+        expect { ApiPagination.paginate(collection) }.to_not raise_error
+      end
     end
   end
 end

--- a/spec/active_record_spec.rb
+++ b/spec/active_record_spec.rb
@@ -7,14 +7,35 @@ ActiveRecord::Base.establish_connection(
   schema: 'support/active_record/schema'
 )
 
-describe 'using kaminari with active_record' do
+shared_examples 'produces_correct_sql' do 
   let(:collection) { Foo.all }
   let(:per_page) { 5 }
 
   it 'produces correct sql for first page' do
     paginated_sql = ApiPagination.paginate(collection, per_page: per_page)
                                  .to_sql
-
     expect(paginated_sql).to eql(Foo.limit(per_page).offset(0).to_sql)
+  end
+end
+
+if ApiPagination.config.paginator == :kaminari
+  describe 'pagination with kaminari' do
+    before do 
+      ApiPagination.config.paginator = :kaminari
+    end
+
+    include_examples 'produces_correct_sql'
+  end
+end
+
+if ApiPagination.config.paginator == :will_paginate
+  require 'will_paginate/active_record'
+
+  describe 'pagination with will_paginate' do 
+    before do 
+      ApiPagination.config.paginator = :will_paginate
+    end
+
+    include_examples 'produces_correct_sql'
   end
 end

--- a/spec/active_record_spec.rb
+++ b/spec/active_record_spec.rb
@@ -23,7 +23,6 @@ describe 'ActiveRecord Support' do
 
   if ApiPagination.config.paginator == :kaminari
     context 'pagination with kaminari' do
-      before { ApiPagination.config.paginator = :kaminari }
       include_examples 'produces_correct_sql'
     end
   end
@@ -32,7 +31,6 @@ describe 'ActiveRecord Support' do
     require 'will_paginate/active_record'
   
     context 'pagination with will_paginate' do 
-      before { ApiPagination.config.paginator = :will_paginate }
       include_examples 'produces_correct_sql'
     end
   end

--- a/spec/active_record_spec.rb
+++ b/spec/active_record_spec.rb
@@ -20,19 +20,13 @@ end
 describe 'ActiveRecord Support' do 
   let(:collection) { Foo.all }
   let(:per_page) { 5 }
-
-  if ApiPagination.config.paginator == :kaminari
-    context 'pagination with kaminari' do
-      include_examples 'produces_correct_sql'
-    end
-  end
   
   if ApiPagination.config.paginator == :will_paginate
     require 'will_paginate/active_record'
-  
-    context 'pagination with will_paginate' do 
-      include_examples 'produces_correct_sql'
-    end
+  end
+
+  context "pagination with #{ApiPagination.config.paginator}" do 
+    include_examples 'produces_correct_sql'
   end
 
   context 'reflections' do

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -281,6 +281,14 @@ describe NumbersController, :type => :controller do
         end
       end
 
+      after :all do 
+        class Fixnum
+          class << self
+            undef_method :default_per_page, :per_page
+          end
+        end
+      end
+
       it 'should use default per page from model' do
         get :index_with_no_per_page, params: {count: 100}
 
@@ -302,17 +310,10 @@ describe NumbersController, :type => :controller do
           end
         )
       end
+    end
 
-      # This spec has to be last because if we undefine these methods
-      # at runtime and then invoke another test that uses them, they will
-      # raise a NoMethodError
+    context 'default per page in objects without paginator defaults' do 
       it 'should not fail if model does not respond to per page' do
-        class Fixnum
-          class << self
-            undef_method :default_per_page, :per_page
-          end
-        end
-
         get :index_with_no_per_page, params: {count: 100}
 
         expect(response.header['Per-Page']).to eq(

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -294,6 +294,7 @@ describe NumbersController, :type => :controller do
 
         expect(response.header['Per-Page']).to eq(
           case ApiPagination.config.paginator
+          when :pagy          then Pagy::VARS[:items].to_s
           when :kaminari      then Kaminari.config.default_per_page.to_s
           when :will_paginate then WillPaginate.per_page.to_s
           end

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -279,6 +279,7 @@ describe NumbersController, :type => :controller do
 
           expect(response.header['Per-Page']).to eq(
             case ApiPagination.config.paginator
+            when :pagy          then Pagy::VARS[:items].to_s
             when :kaminari      then Kaminari.config.default_per_page.to_s
             when :will_paginate then WillPaginate.per_page.to_s
             end

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -214,8 +214,11 @@ describe NumbersController, :type => :controller do
       end
     end
 
-    context 'paginate array options' do
-      shared_examples 'properly set Total header' do
+    if ApiPagination.config.paginator.to_sym == :kaminari
+      context 'paginate array options' do
+        let(:paginate_array_total_count) { 300 }
+        let(:total_header) { 300 }
+        let(:count) { 50 }
         let(:params) do
           {
             paginate_array_total_count: paginate_array_total_count,
@@ -223,92 +226,64 @@ describe NumbersController, :type => :controller do
           }
         end
 
-        specify do
+        it 'has a properly set Total header' do
           get :index_with_paginate_array_options, params: params
 
           expect(response.header['Total']).to be_kind_of(String)
           expect(response.header['Total'].to_i).to eq total_header
         end
       end
-
-      context 'kaminari' do
-        around do |example|
-          paginator = ApiPagination.config.paginator
-          ApiPagination.config.paginator = :kaminari
-          example.run
-          ApiPagination.config.paginator = paginator
-        end
-
-        it_should_behave_like 'properly set Total header' do
-          let(:paginate_array_total_count) { 300 }
-          let(:total_header) { 300 }
-          let(:count) { 50 }
-        end
-      end
-
-      context 'will_paginate' do
-        around do |example|
-          paginator = ApiPagination.config.paginator
-          ApiPagination.config.paginator = :will_paginate
-          example.run
-          ApiPagination.config.paginator = paginator
-        end
-
-        it_should_behave_like 'properly set Total header' do
-          let(:paginate_array_total_count) { 300 }
-          let(:total_header) { 50 }
-          let(:count) { 50 }
-        end
-      end
     end
 
-    context 'default per page in model' do
-      before do
-        class Fixnum
-          @default_per_page = 6
-          @per_page = 6
+    if [:will_paginate, :kaminari].include?(ApiPagination.config.paginator.to_sym)
+      context 'default per page in model' do
+        before do
+          class Fixnum
+            @default_per_page = 6
+            @per_page = 6
 
-          class << self
-            attr_accessor :default_per_page, :per_page
+            class << self
+              attr_accessor :default_per_page, :per_page
+            end
           end
         end
-      end
 
-      after do
-        class Fixnum
-          @default_per_page = 25
-          @per_page = 25
-        end
-      end
-
-      after :all do 
-        class Fixnum
-          class << self
-            undef_method :default_per_page, :per_page
+        after do
+          class Fixnum
+            @default_per_page = 25
+            @per_page = 25
           end
         end
-      end
 
-      it 'should use default per page from model' do
-        get :index_with_no_per_page, params: {count: 100}
-
-        expect(response.header['Per-Page']).to eq('6')
-      end
-
-      it 'should not fail if the model yields nil for per page' do
-        class Fixnum
-          @default_per_page = nil
-          @per_page = nil
+        after :all do 
+          class Fixnum
+            class << self
+              undef_method :default_per_page, :per_page
+            end
+          end
         end
 
-        get :index_with_no_per_page, params: {count: 100}
+        it 'should use default per page from model' do
+          get :index_with_no_per_page, params: {count: 100}
 
-        expect(response.header['Per-Page']).to eq(
-          case ApiPagination.config.paginator
-          when :kaminari      then Kaminari.config.default_per_page.to_s
-          when :will_paginate then WillPaginate.per_page.to_s
+          expect(response.header['Per-Page']).to eq('6')
+        end
+
+        it 'should not fail if the model yields nil for per page' do
+          class Fixnum
+            @default_per_page = nil
+            @per_page = nil
           end
-        )
+
+          get :index_with_no_per_page, params: {count: 100}
+
+          expect(response.header['Per-Page']).to eq(
+            case ApiPagination.config.paginator
+            when :kaminari      then Kaminari.config.default_per_page.to_s
+            when :will_paginate then WillPaginate.per_page.to_s
+            end
+          )
+        end
       end
     end
 

--- a/spec/support/active_record/foo.rb
+++ b/spec/support/active_record/foo.rb
@@ -1,0 +1,3 @@
+require 'active_record'
+
+class Foo < ActiveRecord::Base; end

--- a/spec/support/active_record/schema.rb
+++ b/spec/support/active_record/schema.rb
@@ -1,0 +1,5 @@
+ActiveRecord::Schema.define(version: 0) do
+  create_table "foos", :force => true do |t|
+    t.string   "foo"
+  end
+end


### PR DESCRIPTION
It appears that this library services ActiveRecord primarily, so I wanted to use `#klass` instead of reifying it from the table name because it broke for me earlier in the following situation: 

- Table named `diy_links`.
- Model named `DIYLink`.
- Method attempts to reify `DiyLink` and fails.

I will add a spec later today, hope this is helpful! 👍 