### PR TITLE
Remove last link header when include total option is false

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ ApiPagination.configure do |config|
   config.per_page_param do |params|
     params[:page][:size]
   end
+ 
+  # Optional: Include the total and last_page link header
+  # By default, this is set to true
+  # Note: When using kaminari, this prevents the count call to the database
+  config.include_total = false 
 end
 ```
 

--- a/lib/api-pagination.rb
+++ b/lib/api-pagination.rb
@@ -76,7 +76,7 @@ module ApiPagination
         end
 
         unless pagy.page == pagy.pages
-          pages[:last] = pagy.pages
+          pages[:last] = pagy.pages if ApiPagination.config.include_total
           pages[:next] = pagy.next
         end
       end

--- a/lib/api-pagination.rb
+++ b/lib/api-pagination.rb
@@ -30,7 +30,7 @@ module ApiPagination
         end
 
         unless collection.last_page? || (ApiPagination.config.paginator == :kaminari && collection.out_of_range?)
-          pages[:last] = collection.total_pages
+          pages[:last] = collection.total_pages if ApiPagination.config.include_total
           pages[:next] = collection.current_page + 1
         end
       end
@@ -90,7 +90,9 @@ module ApiPagination
       end
 
       collection = Kaminari.paginate_array(collection, paginate_array_options) if collection.is_a?(Array)
-      [collection.page(options[:page]).per(options[:per_page]), nil]
+      collection = collection.page(options[:page]).per(options[:per_page])
+      collection.without_count if !collection.is_a?(Array) && !ApiPagination.config.include_total
+      [collection, nil]
     end
 
     def paginate_with_will_paginate(collection, options)

--- a/spec/grape_spec.rb
+++ b/spec/grape_spec.rb
@@ -6,7 +6,8 @@ require 'support/shared_examples/last_page'
 
 describe NumbersAPI do
   describe 'GET #index' do
-    let(:links) { last_response.headers['Link'].split(', ') }
+    let(:link) { last_response.headers['Link'] }
+    let(:links) { link.split(', ') }
     let(:total) { last_response.headers['Total'].to_i }
     let(:per_page) { last_response.headers['Per-Page'].to_i }
 
@@ -137,6 +138,12 @@ describe NumbersAPI do
         get '/numbers', count: 10
 
         expect(last_response.header['Total']).to be_nil
+      end
+
+      it 'should not include a link with rel "last"' do
+        get '/numbers', count: 100
+
+        expect(link).to_not include('rel="last"')
       end
 
       after { ApiPagination.config.include_total = true }

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -8,7 +8,8 @@ describe NumbersController, :type => :controller do
   before { request.host = 'example.org' }
 
   describe 'GET #index' do
-    let(:links) { response.headers['Link'].split(', ') }
+    let(:link) { response.headers['Link'] }
+    let(:links) { link.split(', ') }
     let(:total) { response.headers['Total'].to_i }
     let(:per_page) { response.headers['Per-Page'].to_i }
 
@@ -132,6 +133,12 @@ describe NumbersController, :type => :controller do
         get :index, params: {count: 10}
 
         expect(response.header['Total']).to be_nil
+      end
+
+      it 'should not include a link with rel "last"' do
+        get :index, params: { count: 100 }
+
+        expect(link).to_not include('rel="last"')
       end
 
       after { ApiPagination.config.include_total = true }

--- a/spec/support/shared_examples/first_page.rb
+++ b/spec/support/shared_examples/first_page.rb
@@ -1,10 +1,10 @@
 shared_examples 'an endpoint with a first page' do
   it 'should not give a link with rel "first"' do
-    expect(links).not_to include('rel="first"')
+    expect(link).not_to include('rel="first"')
   end
 
   it 'should not give a link with rel "prev"' do
-    expect(links).not_to include('rel="prev"')
+    expect(link).not_to include('rel="prev"')
   end
 
   it 'should give a link with rel "last"' do

--- a/spec/support/shared_examples/last_page.rb
+++ b/spec/support/shared_examples/last_page.rb
@@ -1,10 +1,10 @@
 shared_examples 'an endpoint with a last page' do
   it 'should not give a link with rel "last"' do
-    expect(links).not_to include('rel="last"')
+    expect(link).not_to include('rel="last"')
   end
 
   it 'should not give a link with rel "next"' do
-    expect(links).not_to include('rel="next"')
+    expect(link).not_to include('rel="next"')
   end
 
   it 'should give a link with rel "first"' do


### PR DESCRIPTION
When you set the `include_total` option to false, the total number of records is still needed for the last link header. This pr 'fixes' that by not including the last link header when you disable the `include_total` option. When using Kaminari, this prevents the `count` call which can speed up the pagination process by a lot when using big datasets.

In addition I found that when you write the test
```ruby
expect(links).not_to include('rel="prev"')
```
that it check if that string has an exact match to the links **array**. This will thus always be false! Therefore I added the `link` helper which is just the raw header and use that in the specs so it makes a string comparison. 

This pr Closes #85 