### PR TITLE
Use instance_variable_defined? to avoid warning

### DIFF
--- a/lib/api-pagination/configuration.rb
+++ b/lib/api-pagination/configuration.rb
@@ -50,7 +50,11 @@ module ApiPagination
     end
 
     def paginator
-      @paginator || set_paginator
+      if instance_variable_defined? :@paginator
+        @paginator
+      else
+        set_paginator
+      end
     end
 
     def paginator=(paginator)


### PR DESCRIPTION
This avoids Ruby complaining that we're referencing the @paginator instance variable which may not be defined at this point.