### PR TITLE
[BugFix Issue #106] authorize to override count using pagy

### DIFF
--- a/lib/api-pagination.rb
+++ b/lib/api-pagination.rb
@@ -64,7 +64,12 @@ module ApiPagination
     end
 
     def pagy_from(collection, options)
-      count = collection.is_a?(Array) ? collection.count : collection.count(:all)
+      if options[:count]
+        count = options[:count]
+      else
+        count = collection.is_a?(Array) ? collection.count : collection.count(:all)
+      end
+      
       Pagy.new(count: count, items: options[:per_page], page: options[:page])
     end
 


### PR DESCRIPTION
One might want to override the total given in the headers.

It is already possible with will_paginate and kaminari, I modificated the function for pagy in order to have the same possibility.