### PR TITLE
Allow configuration overrides from request options

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,15 @@ class MoviesController < ApplicationController
     # params[:per_page] (which defaults to 25) will be used.
     paginate json: actors, per_page: 10
   end
+
+  # GET /movies/:id/reviews
+  def reviews
+    reviews = Movie.find(params[:id]).reviews
+
+    # Override any configuration setting on request basis.
+    # For example you may want to disable the total count since the count query is slow.
+    paginate json: actors, total_count: false
+  end
 end
 ```
 
@@ -113,6 +122,13 @@ class MoviesController < ApplicationController
     actors = paginate Movie.find(params[:id]).actors, per_page: 10
 
     render json: ActorsSerializer.new(actors)
+  end
+
+  # GET /movies/:id/reviews
+  def reviews
+    reviews = paginate Movie.find(params[:id]).reviews, total_count: false
+
+    render json: ReviewSerializer.new(reviews)
   end
 end
 ```

--- a/lib/rails/pagination.rb
+++ b/lib/rails/pagination.rb
@@ -25,7 +25,15 @@ module Rails
 
     def _paginate_collection(collection, options={})
       options[:page] = ApiPagination.config.page_param(params)
-      options[:per_page] ||= ApiPagination.config.per_page_param(params)
+      default_options = {
+        :per_page        => ApiPagination.config.per_page_param(params),
+        :total_header    => ApiPagination.config.total_header,
+        :per_page_header => ApiPagination.config.per_page_header,
+        :page_header     => ApiPagination.config.page_header,
+        :include_total   => ApiPagination.config.include_total,
+        :paginator       => ApiPagination.config.paginator
+      }
+      options.reverse_merge!(default_options)
 
       collection, pagy = ApiPagination.paginate(collection, options)
 
@@ -38,25 +46,20 @@ module Rails
         links << %(<#{url}?#{new_params.to_param}>; rel="#{k}")
       end
 
-      total_header    = ApiPagination.config.total_header
-      per_page_header = ApiPagination.config.per_page_header
-      page_header     = ApiPagination.config.page_header
-      include_total   = ApiPagination.config.include_total
-
       headers['Link'] = links.join(', ') unless links.empty?
-      headers[per_page_header] = options[:per_page].to_s
-      headers[page_header] = options[:page].to_s unless page_header.nil?
-      headers[total_header] = total_count(pagy || collection, options).to_s if include_total
+      headers[options[:per_page_header]] = options[:per_page].to_s
+      headers[options[:page_header]] = options[:page].to_s unless options[:page_header].nil?
+      headers[options[:total_header]] = total_count(pagy || collection, options).to_s if options[:include_total]
 
       return collection
     end
 
     def total_count(collection, options)
-      total_count = if ApiPagination.config.paginator == :kaminari
+      total_count = if options[:paginator] == :kaminari
         paginate_array_options = options[:paginate_array_options]
         paginate_array_options[:total_count] if paginate_array_options
       end
-      total_count || ApiPagination.total_from(collection)
+      total_count || ApiPagination.total_from(collection, options)
     end
 
     def base_url

--- a/spec/grape_spec.rb
+++ b/spec/grape_spec.rb
@@ -159,5 +159,28 @@ describe NumbersAPI do
         expect(links).to include('<http://example.org/numbers?count=100&page=2&parity%5B%5D=odd&parity%5B%5D=even>; rel="next"')
       end
     end
+
+    context 'request option to not include the total' do
+      it 'should not include a Total header' do
+        get '/numbers_with_inline_options', count: 10
+
+        expect(last_response.header['Total']).to be_nil
+      end
+
+      it 'should not include a link with rel "last"' do
+        get '/numbers_with_inline_options', count: 100
+
+        expect(link).to_not include('rel="last"')
+      end
+    end
+
+    context 'request option to change page_header' do
+      it 'should give a X-Page header' do
+        get '/numbers_with_inline_options', count: 10
+
+        expect(last_response.headers.keys).to include('X-Page')
+        expect(last_response.headers['X-Page'].to_i).to eq(1)
+      end
+    end
   end
 end

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -219,6 +219,29 @@ describe NumbersController, :type => :controller do
           expect(response.header['Per-Page']).to eq('2')
         end
       end
+
+      context 'request option to not include the total' do
+        it 'should not include a Total header' do
+          get :index_with_inline_options, params: {count: 10}
+
+          expect(response.header['Total']).to be_nil
+        end
+
+        it 'should not include a link with rel "last"' do
+          get :index_with_inline_options, params: { count: 100 }
+
+          expect(link).to_not include('rel="last"')
+        end
+      end
+
+      context 'request option to change page_header' do
+        it 'should give a X-Page header' do
+          get :index_with_inline_options, params: {count: 10}
+
+          expect(response.headers.keys).to include('X-Page')
+          expect(response.headers['X-Page'].to_i).to eq(1)
+        end
+      end
     end
 
     if ApiPagination.config.paginator.to_sym == :kaminari

--- a/spec/support/numbers_api.rb
+++ b/spec/support/numbers_api.rb
@@ -38,4 +38,13 @@ class NumbersAPI < Grape::API
   get :numbers_with_enforced_max_per_page  do
     paginate (1..params[:count]).to_a
   end
+
+  desc 'Return some paginated set of numbers with inline options'
+  paginate :per_page => 10
+  params do
+    requires :count, :type => Integer
+  end
+  get :numbers_with_inline_options do
+    paginate (1..params[:count]).to_a, include_total: false, page_header: 'X-Page'
+  end
 end

--- a/spec/support/numbers_controller.rb
+++ b/spec/support/numbers_controller.rb
@@ -45,6 +45,7 @@ Rails.application.routes.draw do
       get :index_with_custom_render
       get :index_with_no_per_page
       get :index_with_paginate_array_options
+      get :index_with_inline_options
     end
   end
 end
@@ -97,6 +98,16 @@ class NumbersController < ActionController::API
     numbers = paginate numbers, paginate_array_options: {total_count: total_count}
 
     render json: NumbersSerializer.new(numbers)
+  end
+
+  def index_with_inline_options
+    total = params.fetch(:count).to_i
+    paginate(
+      :json => (1..total).to_a,
+      :per_page => 10,
+      :include_total => false,
+      :page_header => 'X-Page'
+    )
   end
 end
 


### PR DESCRIPTION
In my own projects I was required to change the configuration on request basis. For example you have `/api/v1` which uses a different header name for the page than `/api/v2`. Using a configuration block in a before action like
```ruby
before do
  ApiPagination.configure do |config|
    config.include_total = false
  end
end
```
is not thread safe and will thus not work on servers like `puma`. Therefore I've added the option to override configs through the paginate options hash. In theory you can even change the paginator between requests.

Hope you like the idea!