### PR TITLE
Add compatibility with Grape >= 1.2.0

### DIFF
--- a/lib/api-pagination/hooks.rb
+++ b/lib/api-pagination/hooks.rb
@@ -1,7 +1,14 @@
 begin; require 'grape'; rescue LoadError; end
 if defined?(Grape::API)
   require 'grape/pagination'
-  Grape::API.send(:include, Grape::Pagination)
+
+  klass = if Grape::VERSION >= '1.2.0' || defined?(Grape::API::Instance)
+    Grape::API::Instance
+  else
+    Grape::API
+  end
+
+  klass.send(:include, Grape::Pagination)
 end
 
 begin; require 'pagy';          rescue LoadError; end

--- a/spec/grape_spec.rb
+++ b/spec/grape_spec.rb
@@ -5,6 +5,8 @@ require 'support/shared_examples/middle_page'
 require 'support/shared_examples/last_page'
 
 describe NumbersAPI do
+  it { is_expected.to be_kind_of(Grape::Pagination) }
+
   describe 'GET #index' do
     let(:link) { last_response.headers['Link'] }
     let(:links) { link.split(', ') }


### PR DESCRIPTION
Fixes the ``undefined method `paginate` for #<Class>``, due to the [recent (internal) changes in `Grape 1.2`](https://github.com/ruby-grape/grape/blob/v1.2.0/UPGRADING.md#upgrading-to--120):

```
Exiting
/usr/src/app/app/controllers/api/something.rb:25:in `block (3 levels) in <class:Something>': undefined local variable or method `paginate' for #<Class:0x00005648e45f79f8> (NameError)
	from /usr/local/bundle/gems/grape-1.2.2/lib/grape/api/instance.rb:88:in `instance_eval'
	from /usr/local/bundle/gems/grape-1.2.2/lib/grape/api/instance.rb:88:in `block in nest'
	from /usr/local/bundle/gems/grape-1.2.2/lib/grape/api/instance.rb:88:in `each'
	from /usr/local/bundle/gems/grape-1.2.2/lib/grape/api/instance.rb:88:in `nest'
	from /usr/local/bundle/gems/grape-1.2.2/lib/grape/dsl/routing.rb:168:in `block in namespace'
	from /usr/local/bundle/gems/grape-1.2.2/lib/grape/dsl/settings.rb:158:in `within_namespace'
	from /usr/local/bundle/gems/grape-1.2.2/lib/grape/dsl/routing.rb:165:in `namespace'
	from /usr/src/app/app/controllers/api/something.rb:14:in `block (2 levels) in <class:Something>'
	from /usr/local/bundle/gems/grape-1.2.2/lib/grape/api/instance.rb:88:in `instance_eval'
	from /usr/local/bundle/gems/grape-1.2.2/lib/grape/api/instance.rb:88:in `block in nest'
	from /usr/local/bundle/gems/grape-1.2.2/lib/grape/api/instance.rb:88:in `each'
	from /usr/local/bundle/gems/grape-1.2.2/lib/grape/api/instance.rb:88:in `nest'
	from /usr/local/bundle/gems/grape-1.2.2/lib/grape/dsl/routing.rb:168:in `block in namespace'
	from /usr/local/bundle/gems/grape-1.2.2/lib/grape/dsl/settings.rb:158:in `within_namespace'
	from /usr/local/bundle/gems/grape-1.2.2/lib/grape/dsl/routing.rb:165:in `namespace'
	from /usr/local/bundle/gems/grape-1.2.2/lib/grape/dsl/routing.rb:216:in `route_param'
	from /usr/src/app/app/controllers/api/something.rb:9:in `block in <class:Something>'
	from /usr/local/bundle/gems/grape-1.2.2/lib/grape/api/instance.rb:88:in `instance_eval'
	from /usr/local/bundle/gems/grape-1.2.2/lib/grape/api/instance.rb:88:in `block in nest'
	from /usr/local/bundle/gems/grape-1.2.2/lib/grape/api/instance.rb:88:in `each'
	from /usr/local/bundle/gems/grape-1.2.2/lib/grape/api/instance.rb:88:in `nest'
	from /usr/local/bundle/gems/grape-1.2.2/lib/grape/dsl/routing.rb:168:in `block in namespace'
	from /usr/local/bundle/gems/grape-1.2.2/lib/grape/dsl/settings.rb:158:in `within_namespace'
	from /usr/local/bundle/gems/grape-1.2.2/lib/grape/dsl/routing.rb:165:in `namespace'
	from /usr/local/bundle/gems/grape-1.2.2/lib/grape/api.rb:119:in `block in add_setup'
	from /usr/local/bundle/gems/grape-1.2.2/lib/grape/api.rb:118:in `each'
	from /usr/local/bundle/gems/grape-1.2.2/lib/grape/api.rb:118:in `add_setup'
	from /usr/local/bundle/gems/grape-1.2.2/lib/grape/api.rb:40:in `block (2 levels) in override_all_methods!'
```

The `grape` changes were introduced in ruby-grape/grape#1803.

This PR should also fix the issue reported in #116.