### PR TITLE
Preload kaminari collections to avoid counting

### DIFF
--- a/lib/api-pagination.rb
+++ b/lib/api-pagination.rb
@@ -96,6 +96,18 @@ module ApiPagination
 
       collection = Kaminari.paginate_array(collection, paginate_array_options) if collection.is_a?(Array)
       collection = collection.page(options[:page]).per(options[:per_page])
+
+      if !collection.is_a?(Array)
+        if ApiPagination.config.include_total
+          # Preload to avoid counting if we are on the last page.
+          #
+          # See: https://github.com/kaminari/kaminari/blob/cd8601cc42b67267c15a13174bc2fc9bd5de1032/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb#L20-L26
+          collection.load
+        else
+          collection.without_count
+        end
+      end
+
       collection.without_count if !collection.is_a?(Array) && !ApiPagination.config.include_total
       [collection, nil]
     end


### PR DESCRIPTION
## Why

The goal of this change is to avoid doing a `COUNT(*)` when paginating a query with only one page of results.

This is important to us because we are running a large postgres database where `COUNT(*)` [tends to add significant overhead](https://wiki.postgresql.org/wiki/Slow_Counting) on our larger multi-gigabyte tables.

## What

- Kaminari contains logic to [avoid doing a count when on last page of a query](https://github.com/kaminari/kaminari/blob/cd8601cc42b67267c15a13174bc2fc9bd5de1032/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb#L21-L26).
- We can leverage this logic by preloading activerecord relations before attempting to paginate.

## Assumptions

This PR is built on the assumption that we will always be loading the relation we are paginating.

## Before

With a search that returns 2 results:

```
(159.6ms)  SELECT COUNT(DISTINCT "contacts"."id") FROM "contacts ...
Contact Load (183.1ms)  SELECT DISTINCT "contacts"."id" ...
```

## After

With a search that returns 2 results:

```
Contact Load (158.2ms)  SELECT DISTINCT "contacts"."id" ...
```


With a search that returns 2 results and a page size of 1 we still get the COUNT:

```
Contact Load (203.2ms)  SELECT DISTINCT "contacts"."id"...
(170.6ms)  SELECT COUNT(DISTINCT "contacts"."id") FROM "contacts"...
```