### PR TITLE
[~] ruby 3 & latest Pagy support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ ApiPagination.configure do |config|
   config.per_page_param do |params|
     params[:page][:size] if params[:page].is_a?(ActionController::Parameters)
   end
- 
+
   # Optional: Include the total and last_page link header
   # By default, this is set to true
   # Note: When using kaminari, this prevents the count call to the database
-  config.include_total = false 
+  config.include_total = false
 end
 ```
 
@@ -71,7 +71,7 @@ end
 Pagy does not have a built-in way to specify a maximum number of items per page, but `api-pagination` will check if you've set a `:max_per_page` variable. To configure this, you can use the following code somewhere in an initializer:
 
 ```ruby
-Pagy::VARS[:max_per_page] = 100
+Pagy::DEFAULT[:max_per_page] = 100
 ```
 
 If left unconfigured, clients can request as many items per page as they wish, so it's highly recommended that you configure this.

--- a/api-pagination.gemspec
+++ b/api-pagination.gemspec
@@ -16,10 +16,16 @@ Gem::Specification.new do |s|
   s.test_files    = Dir['spec/**/*']
   s.require_paths = ['lib']
 
-  s.add_development_dependency 'rspec', '~> 3.0'
-  s.add_development_dependency 'grape', '>= 0.10.0'
-  s.add_development_dependency 'railties', '>= 5.0.0'
-  s.add_development_dependency 'actionpack', '>= 5.0.0'
-  s.add_development_dependency 'sequel', '>= 4.9.0'
-  s.add_development_dependency 'activerecord-nulldb-adapter', '>= 0.3.9'
+  s.required_ruby_version = '> 2.7'
+
+  s.add_development_dependency 'kaminari', '~> 1.2', '>= 1.2.1'
+  s.add_development_dependency 'pagy', '~> 5.1', '>= 5.1.2'
+  s.add_development_dependency 'will_paginate', '~> 3.3', '>= 3.3.1'
+
+  s.add_development_dependency 'rspec', '~> 3.10'
+  s.add_development_dependency 'grape', '~> 1.6'
+  s.add_development_dependency 'railties', '~> 6.1', '>= 6.1.4.1'
+  s.add_development_dependency 'actionpack', '~> 6.1', '>= 6.1.4.1'
+  s.add_development_dependency 'sequel', '~> 5.49'
+  s.add_development_dependency 'activerecord-nulldb-adapter', '~> 0.7.0'
 end

--- a/lib/api-pagination.rb
+++ b/lib/api-pagination.rb
@@ -47,10 +47,10 @@ module ApiPagination
     private
 
     def paginate_with_pagy(collection, options)
-      if Pagy::VARS[:max_per_page] && options[:per_page] > Pagy::VARS[:max_per_page]
-        options[:per_page] = Pagy::VARS[:max_per_page]
+      if Pagy::DEFAULT[:max_per_page] && options[:per_page] > Pagy::DEFAULT[:max_per_page]
+        options[:per_page] = Pagy::DEFAULT[:max_per_page]
       elsif options[:per_page] <= 0
-        options[:per_page] = Pagy::VARS[:items]
+        options[:per_page] = Pagy::DEFAULT[:items]
       end
 
       pagy = pagy_from(collection, options)
@@ -69,7 +69,7 @@ module ApiPagination
       else
         count = collection.is_a?(Array) ? collection.count : collection.count(:all)
       end
-      
+
       Pagy.new(count: count, items: options[:per_page], page: options[:page])
     end
 
@@ -94,7 +94,7 @@ module ApiPagination
         options[:per_page] = get_default_per_page_for_kaminari(collection)
       end
 
-      collection = Kaminari.paginate_array(collection, paginate_array_options) if collection.is_a?(Array)
+      collection = Kaminari.paginate_array(collection, **paginate_array_options) if collection.is_a?(Array)
       collection = collection.page(options[:page]).per(options[:per_page])
       collection.without_count if !collection.is_a?(Array) && !ApiPagination.config.include_total
       [collection, nil]

--- a/spec/api-pagination_spec.rb
+++ b/spec/api-pagination_spec.rb
@@ -11,7 +11,7 @@ describe ApiPagination do
         describe '.paginate' do
           it 'should accept paginate_array_options option' do
             expect(Kaminari).to receive(:paginate_array)
-              .with(collection, paginate_array_options)
+              .with(collection, **paginate_array_options)
               .and_call_original
 
             ApiPagination.paginate(

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -262,7 +262,7 @@ describe NumbersController, :type => :controller do
           end
         end
 
-        after :all do 
+        after :all do
           class Fixnum
             class << self
               undef_method :default_per_page, :per_page
@@ -286,7 +286,7 @@ describe NumbersController, :type => :controller do
 
           expect(response.header['Per-Page']).to eq(
             case ApiPagination.config.paginator
-            when :pagy          then Pagy::VARS[:items].to_s
+            when :pagy          then Pagy::DEFAULT[:items].to_s
             when :kaminari      then Kaminari.config.default_per_page.to_s
             when :will_paginate then WillPaginate.per_page.to_s
             end
@@ -295,13 +295,13 @@ describe NumbersController, :type => :controller do
       end
     end
 
-    context 'default per page in objects without paginator defaults' do 
+    context 'default per page in objects without paginator defaults' do
       it 'should not fail if model does not respond to per page' do
         get :index_with_no_per_page, params: {count: 100}
 
         expect(response.header['Per-Page']).to eq(
           case ApiPagination.config.paginator
-          when :pagy          then Pagy::VARS[:items].to_s
+          when :pagy          then Pagy::DEFAULT[:items].to_s
           when :kaminari      then Kaminari.config.default_per_page.to_s
           when :will_paginate then WillPaginate.per_page.to_s
           end


### PR DESCRIPTION
# What it does?
1. when I tried to upgrade ruby in my RoR application to version 3.0.2 I faced with an error:
```ruby
[1] pry(#<EquipmentManagement::Api::V1::AssetWorkflowsController>)> paginate @model                                                                                                                                                         
ArgumentError: wrong number of arguments (given 2, expected 1)                                                                                                                                                                              
from /Users/viktorsych/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/kaminari-core-1.2.1/lib/kaminari/models/array_extension.rb:70:in `paginate_array' 
```
so first of all it fixes keyword arguments.
2. when I updated pagy to the latest version I got another issue:
```ruby
      Failure/Error: if Pagy::VARS[:max_per_page] && options[:per_page] > Pagy::VARS[:max_per_page]
       
      NameError:
        uninitialized constant Pagy::VARS
 ```
 so I just reflected Pagy constant name change in the repo.
 3. I updated versions of gems in gemspec.
 
 all tests green:
<img width="824" alt="Screenshot 2021-10-25 at 22 36 57" src="https://user-images.githubusercontent.com/4228960/138759021-eb71d4e7-3a1f-4892-a6ef-2010086df3aa.png">

 