### PR TITLE
Support pagy v43

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec
 # Without these, Bundler may override gemspec constraints and install incompatible versions
 gem "kaminari", "~> 1.2", ">= 1.2.1", require: false
 gem "will_paginate", "~> 3.3", ">= 3.3.1", require: false
-gem "pagy", ">= 9.4.0", "< 10.0.0", require: false
+gem "pagy", "~> 43.0", require: false
 
 gem "sqlite3", require: false
 gem "sequel", "~> 5.49", require: false

--- a/api-pagination.gemspec
+++ b/api-pagination.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = "> 2.7"
 
   s.add_development_dependency "kaminari", "~> 1.2", ">= 1.2.1"
-  s.add_development_dependency "pagy", ">= 9.4.0", "< 10.0.0"
+  s.add_development_dependency "pagy", "~> 43.0"
   s.add_development_dependency "will_paginate", "~> 3.3", ">= 3.3.1"
 
   s.add_development_dependency "rspec", "~> 3.10"

--- a/lib/api-pagination.rb
+++ b/lib/api-pagination.rb
@@ -47,10 +47,10 @@ module ApiPagination
     private
 
     def paginate_with_pagy(collection, options)
-      if Pagy::DEFAULT[:max_per_page] && options[:per_page] > Pagy::DEFAULT[:max_per_page]
-        options[:per_page] = Pagy::DEFAULT[:max_per_page]
+      if Pagy.options[:max_per_page] && options[:per_page] > Pagy.options[:max_per_page]
+        options[:per_page] = Pagy.options[:max_per_page]
       elsif options[:per_page] <= 0
-        options[:per_page] = Pagy::DEFAULT[:limit]
+        options[:per_page] = Pagy.options[:limit]
       end
 
       pagy = pagy_from(collection, options)
@@ -73,14 +73,14 @@ module ApiPagination
       # Pagy 9.x requires keyword arguments
       # Use explicit keyword argument syntax to avoid Ruby version quirks
       pagy_options = {count: count, limit: options[:per_page], page: options[:page]}
-      Pagy.new(**pagy_options)
+      Pagy::Offset.new(**pagy_options)
     end
 
     def pagy_pages_from(pagy)
       {}.tap do |pages|
         unless pagy.page == 1
           pages[:first] = 1
-          pages[:prev] = pagy.prev
+          pages[:prev] = pagy.previous
         end
 
         unless pagy.page == pagy.pages

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -285,7 +285,7 @@ describe NumbersController, type: :controller do
 
           expect(response.header["Per-Page"]).to eq(
             case ApiPagination.config.paginator
-            when :pagy then Pagy::DEFAULT[:limit].to_s
+            when :pagy then Pagy.options[:limit].to_s
             when :kaminari then Kaminari.config.default_per_page.to_s
             when :will_paginate then WillPaginate.per_page.to_s
             end
@@ -300,7 +300,7 @@ describe NumbersController, type: :controller do
 
         expect(response.header["Per-Page"]).to eq(
           case ApiPagination.config.paginator
-          when :pagy then Pagy::DEFAULT[:limit].to_s
+          when :pagy then Pagy.options[:limit].to_s
           when :kaminari then Kaminari.config.default_per_page.to_s
           when :will_paginate then WillPaginate.per_page.to_s
           end


### PR DESCRIPTION
Pagy recently released v43, which contained some breaking API changes that affect this gem as well: https://ddnexus.github.io/pagy-pre/guides/upgrade-guide/. This PR updates the gem to detect when it's being used with Pagy >= v43, and to use the appropriate new APIs to interact with Pagy

Unrelated to the Pagy bump, I had to add several dev dependencies to get tests running on my machine on Ruby 3.4.x. I tried downgrading to one of the Ruby versions listed in the travis config, but they all failed to install on my machine. Happy to remove this bit of the code if it's not wanted! 