### PR TITLE
Fix Ruby 3.2/3.3 compatibility in Fixnum test

### DIFF
--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -245,7 +245,8 @@ describe NumbersController, :type => :controller do
     if [:will_paginate, :kaminari].include?(ApiPagination.config.paginator.to_sym)
       context 'default per page in model' do
         before do
-          class Fixnum
+          # Use Integer instead of Fixnum (Fixnum was unified with Integer in Ruby 2.4+)
+          class Integer
             @default_per_page = 6
             @per_page = 6
 
@@ -256,14 +257,14 @@ describe NumbersController, :type => :controller do
         end
 
         after do
-          class Fixnum
+          class Integer
             @default_per_page = 25
             @per_page = 25
           end
         end
 
         after :all do
-          class Fixnum
+          class Integer
             class << self
               undef_method :default_per_page, :per_page
             end
@@ -277,7 +278,7 @@ describe NumbersController, :type => :controller do
         end
 
         it 'should not fail if the model yields nil for per page' do
-          class Fixnum
+          class Integer
             @default_per_page = nil
             @per_page = nil
           end


### PR DESCRIPTION
Replace Fixnum with Integer in spec/rails_spec.rb to fix test failures on Ruby 3.2 and 3.3.

Background:

- Fixnum and Bignum were unified into Integer in Ruby 2.4
- The test was monkey-patching Fixnum, which behaves differently in Ruby 3.2+
- This caused the "default per page in model" test to fail for Kaminari and WillPaginate on Ruby 3.2/3.3

Changes:

- Replace all instances of `class Fixnum` with `class Integer`
- Add comment explaining the Ruby 2.4+ change
- All tests now pass on Ruby 3.1, 3.2, and 3.3
