### PR TITLE
Use Pagy’s new options API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec
 # Without these, Bundler may override gemspec constraints and install incompatible versions
 gem "kaminari", "~> 1.2", ">= 1.2.1", require: false
 gem "will_paginate", "~> 3.3", ">= 3.3.1", require: false
-gem "pagy", "~> 43.0", require: false
+gem "pagy", "~> 43.3", require: false
 
 gem "sqlite3", require: false
 gem "sequel", "~> 5.49", require: false

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ gem 'rails-api'
 gem 'grape', '>= 0.10.0'
 
 # Then choose your preferred paginator from the following:
-gem 'pagy', '>= 43.0.0' # Due to breaking changes, newer versions of api-pagination require pagy 43.0.0 or later
+gem 'pagy'
 gem 'kaminari'
 gem 'will_paginate'
 
@@ -71,7 +71,7 @@ end
 Pagy does not have a built-in way to specify a maximum number of items per page, but `api-pagination` will check if you've set a `:max_per_page` variable. To configure this, you can use the following code somewhere in an initializer:
 
 ```ruby
-Pagy.options[:max_per_page] = 100
+Pagy::OPTIONS[:max_per_page] = 100
 ```
 
 If left unconfigured, clients can request as many items per page as they wish, so it's highly recommended that you configure this.

--- a/api-pagination.gemspec
+++ b/api-pagination.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = "> 2.7"
 
   s.add_development_dependency "kaminari", "~> 1.2", ">= 1.2.1"
-  s.add_development_dependency "pagy", "~> 43.0"
+  s.add_development_dependency "pagy", "~> 43.3"
   s.add_development_dependency "will_paginate", "~> 3.3", ">= 3.3.1"
 
   s.add_development_dependency "rspec", "~> 3.10"

--- a/lib/api-pagination.rb
+++ b/lib/api-pagination.rb
@@ -47,10 +47,10 @@ module ApiPagination
     private
 
     def paginate_with_pagy(collection, options)
-      if Pagy.options[:max_per_page] && options[:per_page] > Pagy.options[:max_per_page]
-        options[:per_page] = Pagy.options[:max_per_page]
+      if Pagy::OPTIONS[:max_per_page] && options[:per_page] > Pagy::OPTIONS[:max_per_page]
+        options[:per_page] = Pagy::OPTIONS[:max_per_page]
       elsif options[:per_page] <= 0
-        options[:per_page] = Pagy.options[:limit]
+        options[:per_page] = Pagy::OPTIONS[:limit]
       end
 
       pagy = pagy_from(collection, options)

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -285,7 +285,7 @@ describe NumbersController, type: :controller do
 
           expect(response.header["Per-Page"]).to eq(
             case ApiPagination.config.paginator
-            when :pagy then Pagy.options[:limit].to_s
+            when :pagy then Pagy::OPTIONS[:limit].to_s
             when :kaminari then Kaminari.config.default_per_page.to_s
             when :will_paginate then WillPaginate.per_page.to_s
             end
@@ -300,7 +300,7 @@ describe NumbersController, type: :controller do
 
         expect(response.header["Per-Page"]).to eq(
           case ApiPagination.config.paginator
-          when :pagy then Pagy.options[:limit].to_s
+          when :pagy then Pagy::OPTIONS[:limit].to_s
           when :kaminari then Kaminari.config.default_per_page.to_s
           when :will_paginate then WillPaginate.per_page.to_s
           end


### PR DESCRIPTION
Pagy.options has been deprecated in version 43.3.0. See https://github.com/ddnexus/pagy/commit/88d52de275e2afc8acdea7255e88a28e3d538728#diff-05ff71ebdb99c42d63eefbef934c5197fc72f8f03b8dbbe363ca53e5615f0429R26

The current state causes the following warning:

    [PAGY] 'Pagy.options' is deprecated: use 'Pagy::OPTIONS directly'

The new Pagy::OPTIONS has actually been introduced in version 43.2.10 but only announced in version 43.3.0. We need to bump the minimal supported version because 43.0 does not support it. https://github.com/ddnexus/pagy/commit/4a70be0ce6dc60cd39420772696975140a8929e8

Since version compatibility is checked through the gem specification, I suggest we remove it from the README. Specifying pagy without version already installs the latest one, and explicit version constraints in users’ Gemfile get outdated and become a hassle then.